### PR TITLE
Correção do retorno dos métodos list_attachments para retorno de lista

### DIFF
--- a/catalog_persistence/databases.py
+++ b/catalog_persistence/databases.py
@@ -111,8 +111,7 @@ class InMemoryDBManager(BaseDBManager):
 
     def list_attachments(self, id):
         doc = self.read(id)
-        if doc.get(self._attachments_key):
-            return list(doc[self._attachments_key].keys())
+        return list(doc.get(self._attachments_key, {}).keys())
 
     def attachment_exists(self, id, file_id):
         doc = self.read(id)
@@ -195,8 +194,7 @@ class CouchDBManager(BaseDBManager):
 
     def list_attachments(self, id):
         doc = self.read(id)
-        if doc.get(self._attachments_key):
-            return list(doc[self._attachments_key].keys())
+        return list(doc.get(self._attachments_key, {}).keys())
 
     def attachment_exists(self, id, file_id):
         doc = self.read(id)
@@ -276,8 +274,10 @@ class DatabaseService:
         }
         if document.get('updated_date'):
             document_record['updated_date'] = document['updated_date']
-        document_record['attachments'] = \
-            self.db_manager.list_attachments(document_id)
+        attachments = self.db_manager.list_attachments(document_id)
+        if attachments:
+            document_record['attachments'] = \
+                self.db_manager.list_attachments(document_id)
         return document_record
 
     def update(self, document_id, document_record):


### PR DESCRIPTION
Correção ao bug reportado na issue #23 .

- Método `BaseDBManager.list_attachments` condiz com assinatura da classe abstrata base.
- Adequação do método `DatabaseService.read` para utilizar o método `BaseDBManager.list_attachments`.

Fixes #23 .