### PR TITLE
[MVP0][tk51] Retirado método attachment_exists

### DIFF
--- a/catalog_persistence/databases.py
+++ b/catalog_persistence/databases.py
@@ -99,7 +99,7 @@ class InMemoryDBManager(BaseDBManager):
         selector: criterio para selecionar campo com determinados valores
             Ex.: {'type': 'ART'}
         fields: lista de campos para retornar. Ex.: ['name']
-        sort: lista de dict com nome de campo e sua ordenacao. [{'name': 'asc'}]
+        sort: lista de dict com nome de campo e sua ordenacao.[{'name': 'asc'}]
 
         Retorno:
         Lista de registros de documento registrados na base de dados
@@ -208,7 +208,7 @@ class CouchDBManager(BaseDBManager):
         selector: criterio para selecionar campo com determinados valores
             Ex.: {'type': 'ART'}
         fields: lista de campos para retornar. Ex.: ['name']
-        sort: lista de dict com nome de campo e sua ordenacao. [{'name': 'asc'}]
+        sort: lista de dict com nome de campo e sua ordenacao.[{'name': 'asc'}]
 
         Retorno:
         Lista de registros de documento registrados na base de dados
@@ -218,7 +218,10 @@ class CouchDBManager(BaseDBManager):
             'fields': fields,
             'sort': sort,
         }
-        return [dict(document) for document in self.database.find(selection_criteria)]
+        return [
+            dict(document)
+            for document in self.database.find(selection_criteria)
+        ]
 
     def put_attachment(self, id, file_id, content, content_properties):
         """
@@ -361,7 +364,7 @@ class DatabaseService:
         selector: criterio para selecionar campo com determinados valores
             Ex.: {'type': 'ART'}
         fields: lista de campos para retornar. Ex.: ['name']
-        sort: lista de dict com nome de campo e sua ordenacao. [{'name': 'asc'}]
+        sort: lista de dict com nome de campo e sua ordenacao.[{'name': 'asc'}]
 
         Retorno:
         Lista de registros de documento registrados na base de dados

--- a/catalog_persistence/databases.py
+++ b/catalog_persistence/databases.py
@@ -55,10 +55,6 @@ class BaseDBManager(metaclass=abc.ABCMeta):
     def list_attachments(self, id) -> list:
         return NotImplemented
 
-    @abc.abstractmethod
-    def attachment_exists(self, id, file_id) -> bool:
-        return NotImplemented
-
 
 class InMemoryDBManager(BaseDBManager):
 
@@ -151,9 +147,6 @@ class InMemoryDBManager(BaseDBManager):
     def list_attachments(self, id):
         doc = self.read(id)
         return list(doc.get(self._attachments_key, {}).keys())
-
-    def attachment_exists(self, id, file_id):
-        return file_id in self.list_attachments(id)
 
 
 class CouchDBManager(BaseDBManager):
@@ -251,9 +244,6 @@ class CouchDBManager(BaseDBManager):
     def list_attachments(self, id):
         doc = self.read(id)
         return list(doc.get(self._attachments_key, {}).keys())
-
-    def attachment_exists(self, id, file_id):
-        return file_id in self.list_attachments(id)
 
 
 class DatabaseService:

--- a/catalog_persistence/tests/test_databases.py
+++ b/catalog_persistence/tests/test_databases.py
@@ -181,9 +181,10 @@ def test_put_attachment_to_document(setup, database_service, xml_test):
         article_record['document_id'],
         article_record
     )
+    file_id = "href_file"
     database_service.put_attachment(
         document_id=article_record['document_id'],
-        file_id="href_file",
+        file_id=file_id,
         content=xml_test.encode('utf-8'),
         file_properties={
             'content_type': "text/xml",
@@ -195,17 +196,16 @@ def test_put_attachment_to_document(setup, database_service, xml_test):
         database_service.db_manager.database[article_record['document_id']]
     )
     assert record_check is not None
-    assert database_service.db_manager.attachment_exists(
-        article_record['document_id'],
-        "href_file"
+    assert file_id in database_service.db_manager.list_attachments(
+        article_record['document_id']
     )
 
 
 @patch.object(DatabaseService, 'update')
 def test_put_attachment_to_document_update(mocked_update,
-                                                    setup,
-                                                    database_service,
-                                                    xml_test):
+                                           setup,
+                                           database_service,
+                                           xml_test):
     article_record = get_article_record({'Test': 'Test9'})
     database_service.register(
         article_record['document_id'],
@@ -233,8 +233,8 @@ def test_put_attachment_to_document_update(mocked_update,
 
 
 def test_put_attachment_to_document_update_dates(setup,
-                                        database_service,
-                                        xml_test):
+                                                 database_service,
+                                                 xml_test):
     article_record = get_article_record({'Test': 'Test9'})
     database_service.register(
         article_record['document_id'],


### PR DESCRIPTION
Fixes #51 :

- Retirado método `attachment_exists`, que não é mais utilizado.
- Refatorado teste que utilizava o método.
- PEP8[E501] - Linhas maiores que 79 colunas
