### PR TITLE
Ajusta uso incorreto do renderer JSON, na API.

### DIFF
--- a/catalogmanager_api/tests/test_article.py
+++ b/catalogmanager_api/tests/test_article.py
@@ -49,7 +49,7 @@ def test_http_get_article_not_found(mocked_get_article_data, testapp):
     }
     result = testapp.get('/articles/{}'.format(article_id))
     assert result.status == '200 OK'
-    assert result.json == json.dumps(expected)
+    assert result.json == expected
 
 
 @patch.object(catalogmanager, 'get_article_data')
@@ -66,7 +66,7 @@ def test_http_get_article_succeeded(mocked_get_article_data, testapp):
     mocked_get_article_data.return_value = expected
     result = testapp.get('/articles/{}'.format(article_id))
     assert result.status == '200 OK'
-    assert result.json == json.dumps(expected)
+    assert result.json == expected
 
 
 @patch.object(catalogmanager, 'get_article_file')
@@ -282,7 +282,7 @@ def test_http_article_calls_put_article_service_error(mocked_put_article,
                          params=params,
                          content_type='multipart/form-data')
     assert result.status == '200 OK'
-    assert result.json == json.dumps(expected)
+    assert result.json == expected
 
 
 @patch.object(catalogmanager, 'put_article')

--- a/catalogmanager_api/views/article.py
+++ b/catalogmanager_api/views/article.py
@@ -1,6 +1,5 @@
 import os
 import io
-import json
 
 from pyramid.response import Response
 from pyramid.view import view_config
@@ -48,10 +47,10 @@ class Article:
                 **self.db_settings
             )
         except catalogmanager.article_services.ArticleServicesException as e:
-            return json.dumps({
+            return {
                 "error": "500",
                 "message": "Article error"
-            })
+            }
 
     def get(self):
         try:
@@ -59,12 +58,12 @@ class Article:
                 article_id=self.request.matchdict['id'],
                 **self.db_settings
             )
-            return json.dumps(article_data)
+            return article_data
         except catalogmanager.article_services.ArticleServicesException as e:
-            return json.dumps({
+            return {
                 "error": "404",
                 "message": e.message
-            })
+            }
 
     @view_config(route_name='get_article_xml')
     def get_article_xml(self):

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -35,7 +35,7 @@ def test_add_article_register_change(testapp, setup_db, test_package_A):
     result = testapp.get(url)
     assert result.status_code == 200
     assert result.json is not None
-    res_dict = json.loads(result.json)
+    res_dict = result.json
     assert res_dict.get("document_id") == article_id
     assert res_dict.get("content") is not None
     assert res_dict["content"]["xml"] == os.path.basename(xml_file_path)


### PR DESCRIPTION
Da maneira que estava implementado, o retorno estava sendo serializado
em JSON 2 vezes: a primeira explicitamente na view-function e a segunda
pelo renderer do Pyramid. Isso ocorre pois o argumento
``renderer="json"`` está sendo passado para o decorador ``resource``, na
classe ``Article``. A maneira correta de se utilizar renderers é
retornando instâncias de objetos padrão do Python, e o framework se
encarrega da serialização no formato especificado.

Veja mais em https://docs.pylonsproject.org/projects/pyramid/en/1.9-branch/narr/renderers.html