### PR TITLE
[MVP0][tk53] Identificadas classes Article e Asset como Document

### DIFF
--- a/catalogmanager/__init__.py
+++ b/catalogmanager/__init__.py
@@ -1,7 +1,7 @@
 from catalogmanager.article_services import (
     ArticleServices
 )
-from catalogmanager.models.article_model import Article
+from catalogmanager.models.article_model import ArticleDocument
 from catalogmanager.models.file import File
 from catalog_persistence.databases import CouchDBManager
 
@@ -59,7 +59,7 @@ def get_asset_file(article_id, asset_id, db_host, db_port, username, password):
 
 def set_assets_public_url(article_id, xml_content, assets_filenames,
                           public_url):
-    article = Article(article_id)
+    article = ArticleDocument(article_id)
     xml_file = File("xml_file.xml")
     xml_file.content = xml_content
     xml_file.size = len(xml_content)

--- a/catalogmanager/article_services.py
+++ b/catalogmanager/article_services.py
@@ -7,7 +7,7 @@ from catalog_persistence.models import (
 from catalog_persistence.databases import DocumentNotFound
 from catalog_persistence.services import DatabaseService
 from .models.article_model import (
-    Article,
+    ArticleDocument,
 )
 from .models.file import File
 
@@ -47,7 +47,7 @@ class ArticleServices:
         return article.unexpected_files_list, article.missing_files_list
 
     def receive_xml_file(self, id, **xml_properties):
-        article = Article(id)
+        article = ArticleDocument(id)
 
         xml_file = File(xml_properties['filename'])
         xml_file.content = xml_properties['content']
@@ -92,12 +92,12 @@ class ArticleServices:
             return article_record
         except DocumentNotFound:
             raise ArticleServicesException(
-                'Article {} not found'.format(article_id)
+                'ArticleDocument {} not found'.format(article_id)
             )
 
     def get_article_file(self, article_id):
         article_record = self.get_article_data(article_id)
-        article = Article(article_id)
+        article = ArticleDocument(article_id)
         try:
             attachment = self.article_db_service.get_attachment(
                 document_id=article_id,
@@ -143,6 +143,6 @@ class ArticleServices:
             return content_type, content
         except DocumentNotFound:
             raise ArticleServicesException(
-                'Asset file {} (Article {}) not found. '.format(
+                'AssetDocument file {} (ArticleDocument {}) not found.'.format(
                     asset_id, article_id)
             )

--- a/catalogmanager/models/article_model.py
+++ b/catalogmanager/models/article_model.py
@@ -8,7 +8,7 @@ from .file import (
 )
 
 
-class Asset:
+class AssetDocument:
 
     def __init__(self, asset_node):
         self.file = None
@@ -26,7 +26,7 @@ class Asset:
             self.node.href = value
 
 
-class Article:
+class ArticleDocument:
 
     def __init__(self, article_id):
         self.id = article_id
@@ -43,7 +43,7 @@ class Article:
         self.xml_tree = ArticleXMLTree()
         self.xml_tree.content = self._xml_file.content
         self.assets = {
-            name: Asset(node)
+            name: AssetDocument(node)
             for name, node in self.xml_tree.asset_nodes.items()
         }
 

--- a/catalogmanager/tests/test_article_model.py
+++ b/catalogmanager/tests/test_article_model.py
@@ -1,6 +1,6 @@
 
 from catalogmanager.models.article_model import (
-    Article,
+    ArticleDocument,
 )
 from catalogmanager.xml.xml_tree import (
     XMLTree,
@@ -9,7 +9,7 @@ from catalogmanager.xml.xml_tree import (
 
 def test_article(test_package_A, test_packA_filenames,
                  test_packA_assets_files):
-    article = Article('ID')
+    article = ArticleDocument('ID')
     xml_file = test_package_A[0]
     article.xml_file = xml_file
     article.update_asset_files(test_packA_assets_files)
@@ -29,7 +29,7 @@ def test_article(test_package_A, test_packA_filenames,
 
 
 def test_missing_files_list(test_package_B):
-    article = Article('ID')
+    article = ArticleDocument('ID')
     article.xml_file = test_package_B[0]
     assets_files = [
         {
@@ -56,7 +56,7 @@ def test_missing_files_list(test_package_B):
 
 
 def test_unexpected_files_list(test_package_C, test_packC_filenames):
-    article = Article('ID')
+    article = ArticleDocument('ID')
     article.xml_file = test_package_C[0]
     assets_files = [
         {
@@ -85,7 +85,7 @@ def test_update_href(test_package_A, test_packA_filenames,
                      test_packA_assets_files):
     new_href = 'novo href'
     filename = '0034-8910-rsp-S01518-87872016050006741-gf01.jpg'
-    article = Article('ID')
+    article = ArticleDocument('ID')
     article.xml_file = test_package_A[0]
     article.update_asset_files(test_packA_assets_files)
     content = article.xml_tree.content

--- a/catalogmanager/tests/test_article_services.py
+++ b/catalogmanager/tests/test_article_services.py
@@ -10,7 +10,7 @@ from catalogmanager.article_services import (
     ArticleServicesException
 )
 from catalogmanager.models.article_model import (
-    Article,
+    ArticleDocument,
 )
 from catalogmanager.xml.xml_tree import (
     XMLTree
@@ -43,7 +43,7 @@ def test_receive_xml_file(change_service, test_package_A,
 
 def test_receive_package(change_service, test_package_A,
                          test_packA_assets_files):
-    article = Article('ID')
+    article = ArticleDocument('ID')
     xml_file = test_package_A[0]
     article.xml_file = xml_file
     article.update_asset_files(test_packA_assets_files)


### PR DESCRIPTION
Closes #53 

- Alteradas classes `Article` e `Asset` como `ArticleDocument` e `AssetDocument`, respectivamente, no módulo `catalogmanager`.