### PR TITLE
[MVP1][tk86] Implementa o serviço para recuperar histórico de mudanças na API

### DIFF
--- a/catalog_persistence/services.py
+++ b/catalog_persistence/services.py
@@ -210,6 +210,10 @@ class DatabaseService:
         Retorno:
         Lista de registros de mudança
         """
+        def convert_change_type(change):
+            change.update({'type': ChangeType(change['type']).name})
+            return change
+
         fields = [
             'change_id',
             'document_id',
@@ -222,8 +226,12 @@ class DatabaseService:
                 (QueryOperator.GREATER_THAN, last_sequence)
             ]
         }
-        sort = [{'change_id': SortOrder.ASC.value}]
-        return self.changes_db_manager.find(fields=fields,
-                                            limit=limit,
-                                            filter=filter,
-                                            sort=sort)
+        sort = [{'created_date': SortOrder.ASC.value}]
+        changes = self.changes_db_manager.find(fields=fields,
+                                               limit=limit,
+                                               filter=filter,
+                                               sort=sort)
+        return [
+            convert_change_type(change)
+            for change in changes
+        ]

--- a/catalog_persistence/services.py
+++ b/catalog_persistence/services.py
@@ -2,11 +2,18 @@ from datetime import datetime
 from enum import Enum
 from uuid import uuid4
 
+from .databases import QueryOperator
+
 
 class ChangeType(Enum):
     CREATE = 'C'
     UPDATE = 'U'
     DELETE = 'D'
+
+
+class SortOrder(Enum):
+    ASC = 'asc'
+    DESC = 'desc'
 
 
 class DatabaseService:
@@ -188,3 +195,35 @@ class DatabaseService:
         DocumentNotFound: documento não encontrado na base de dados.
         """
         return self.db_manager.get_attachment_properties(document_id, file_id)
+
+    def list_changes(self, last_sequence, limit):
+        """
+        Busca registros de mudança a partir do sequencial informado e retorna
+        a lista com, no máximo, o limite informado.
+
+        Params:
+        :param last_sequence: sequencial de mudança, que deve ser a referência
+            para a busca dos sequenciais a serem listados.
+        :param limit: limite máximo de registros de mudança que devem ser
+            listados.
+
+        Retorno:
+        Lista de registros de mudança
+        """
+        fields = [
+            'change_id',
+            'document_id',
+            'document_type',
+            'type',
+            'created_date'
+        ]
+        filter = {
+            'change_id': [
+                (QueryOperator.GREATER_THAN, last_sequence)
+            ]
+        }
+        sort = [{'change_id': SortOrder.ASC.value}]
+        return self.changes_db_manager.find(fields=fields,
+                                            limit=limit,
+                                            filter=filter,
+                                            sort=sort)

--- a/catalog_persistence/tests/conftest.py
+++ b/catalog_persistence/tests/conftest.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from random import randint
 
 from pyramid import testing
 import pytest
@@ -63,32 +64,30 @@ def setup(request, persistence_config, database_service):
 
 
 @pytest.fixture
-def inmemory_db_setup(request, persistence_config, inmemory_db_service):
+def inmemory_db_setup(request, persistence_config):
+    inmemory_db_service = DatabaseService(
+        InMemoryDBManager(database_name='articles'),
+        InMemoryDBManager(database_name='changes')
+    )
+
     def fin():
         inmemory_db_service.changes_db_manager.drop_database()
     request.addfinalizer(fin)
+    return inmemory_db_service
 
 
 @pytest.fixture
 def test_changes_records(request):
     changes_list = []
     for sequential in range(1, 11):
+        document_type = ['C', 'U', 'D']
         change_record = {
-            'change_id': 'SEQ{:0>17}'.format(sequential),
+            'change_id': '{:0>17}'.format(sequential),
             'document_id': 'DOC-ID-{}'.format(sequential),
-            'document_type': RecordType.DOCUMENT.value,
-            'type': ChangeType.CREATE.value,
+            'type': document_type[randint(0, 2)],
             'created_date': str(datetime.utcnow().timestamp())
         }
         changes_list.append(change_record)
-        file_id = "{}.xml".format(change_record['document_id'])
-        update_change_record = {
-                'type': ChangeType.UPDATE.value,
-                'updated_date': str(datetime.utcnow().timestamp()),
-                'attachment_id': file_id
-        }
-        update_change_record.update(change_record)
-        changes_list.append(update_change_record)
     return changes_list
 
 

--- a/catalog_persistence/tests/conftest.py
+++ b/catalog_persistence/tests/conftest.py
@@ -9,8 +9,7 @@ from catalog_persistence.databases import (
     CouchDBManager,
     InMemoryDBManager,
 )
-from catalog_persistence.models import RecordType
-from catalog_persistence.services import DatabaseService, ChangeType
+from catalog_persistence.services import DatabaseService
 
 
 @pytest.yield_fixture
@@ -93,7 +92,7 @@ def test_changes_records(request):
 
 @pytest.fixture
 def test_documents_records(request):
-    fields_values = ('SEQ{:0>17}', 'field_{}')
+    fields_values = ('{:0>17}', 'field_{}')
     return tuple(
         {
             'document_id': fields_values[0].format(sequential),
@@ -113,7 +112,7 @@ def no_filter_all(request, test_documents_records):
 
 @pytest.fixture
 def filter_greater_than_result(request, test_documents_records):
-    initial_id = 'SEQ{:0>17}'.format(5)
+    initial_id = '{:0>17}'.format(5)
     find_criteria = {
         'filter': {
             'document_id': [
@@ -130,14 +129,14 @@ def filter_greater_than_result(request, test_documents_records):
             for field in ['document_id', 'field']
         }
         for document_record in test_documents_records
-        if document_record['document_id'] > initial_id
+        if initial_id < document_record['document_id']
     )
     return (find_criteria, expected)
 
 
 @pytest.fixture
 def filter_limit_result(request, test_documents_records):
-    limit_id = 'SEQ{:0>17}'.format(5)
+    limit_id = '{:0>17}'.format(5)
     find_criteria = {
         'filter': {},
         'fields': ['document_id', 'field'],

--- a/catalog_persistence/tests/test_databases.py
+++ b/catalog_persistence/tests/test_databases.py
@@ -504,3 +504,21 @@ def test_get_attachment_properties(setup, database_service, xml_test):
             article_record['document_id'],
             'href_file'
         )
+
+
+def test_find_documents_by_selected_field_returns_according_to_filter(
+    setup,
+    database_service,
+    test_documents_records,
+    find_criteria_result
+):
+    find_args, expected = find_criteria_result
+    for document_record in test_documents_records:
+        database_service.db_manager.create(document_record['document_id'],
+                                           document_record)
+
+    check_list = database_service.db_manager.find(**find_args)
+    assert isinstance(check_list[0], dict)
+    assert len(check_list) == len(expected)
+    for check_document, expected_document in zip(check_list, expected):
+        assert check_document == expected_document

--- a/catalog_persistence/tests/test_services.py
+++ b/catalog_persistence/tests/test_services.py
@@ -1,45 +1,71 @@
-from unittest.mock import Mock
-
-from catalog_persistence.databases import QueryOperator
-from catalog_persistence.services import SortOrder
 
 
-def test_list_changes_returns_db_manager_find_result(setup,
-                                                     database_service,
-                                                     test_changes_records,
-                                                     xml_test):
-    expected_list = test_changes_records
-    test_changes_db_manager = database_service.changes_db_manager
-    database_service.changes_db_manager = Mock()
-    database_service.changes_db_manager.find = Mock()
-    database_service.changes_db_manager.find.return_value = expected_list
-    last_sequence = 'SEQ1'
-    filter_called = {
-        'change_id': [
-            (QueryOperator.GREATER_THAN, last_sequence)
-        ]
-    }
+def test_list_changes_returns_db_manager_find_all(inmemory_db_setup,
+                                                  test_changes_records,
+                                                  xml_test):
+    for change_record in test_changes_records:
+        inmemory_db_setup.changes_db_manager.create(change_record['change_id'],
+                                                    change_record)
+    last_sequence = ''
     limit = 10
-    fields_called = [
-        'change_id',
-        'document_id',
-        'document_type',
-        'type',
-        'created_date'
-    ]
-    sorted_called = [{'change_id': SortOrder.ASC.value}]
-    check_list = database_service.list_changes(last_sequence='SEQ1',
-                                               limit=limit)
-    database_service.changes_db_manager.find.assert_called_once_with(
-        fields=fields_called,
-        limit=limit,
-        filter=filter_called,
-        sort=sorted_called
-    )
-    database_service.changes_db_manager = test_changes_db_manager
-    assert len(check_list) == len(expected_list)
-    for check_list_item, expected_item in zip(check_list, expected_list):
-        assert check_list_item['document_id'] == expected_item['document_id']
-        assert check_list_item['document_type'] ==\
-            expected_item['document_type']
-        assert check_list_item['created_date'] is not None
+    check_list = inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                                limit=limit)
+    assert len(check_list) == len(test_changes_records)
+    for check_item, expected_item in zip(check_list, test_changes_records):
+        assert check_item['change_id'] == expected_item['change_id']
+        assert check_item['document_id'] == expected_item['document_id']
+        assert check_item['type'] == expected_item['type']
+        assert check_item['created_date'] is not None
+
+
+def test_list_changes_returns_db_manager_find_from_last(inmemory_db_setup,
+                                                        test_changes_records,
+                                                        xml_test):
+    for change_record in test_changes_records:
+        inmemory_db_setup.changes_db_manager.create(change_record['change_id'],
+                                                    change_record)
+    last_record = 4
+    last_sequence = test_changes_records[last_record]['change_id']
+    limit = 10
+    check_list = inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                                limit=limit)
+    assert len(check_list) == len(test_changes_records[last_record + 1:])
+    for check_item, expected_item in \
+            zip(check_list, test_changes_records[last_record + 1:]):
+        assert check_item['change_id'] == expected_item['change_id']
+        assert check_item['document_id'] == expected_item['document_id']
+        assert check_item['type'] == expected_item['type']
+        assert check_item['created_date'] is not None
+
+
+def test_list_changes_returns_db_manager_find_limit(inmemory_db_setup,
+                                                    test_changes_records,
+                                                    xml_test):
+    for change_record in test_changes_records:
+        inmemory_db_setup.changes_db_manager.create(change_record['change_id'],
+                                                    change_record)
+    last_record = 2
+    last_sequence = test_changes_records[last_record]['change_id']
+    limit = 5
+    check_list = inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                                limit=limit)
+    assert len(check_list) == len(test_changes_records[last_record + 1:])
+    for check_item, expected_item in \
+            zip(check_list, test_changes_records[last_record + 1:limit + 1]):
+        assert check_item['change_id'] == expected_item['change_id']
+        assert check_item['document_id'] == expected_item['document_id']
+        assert check_item['type'] == expected_item['type']
+        assert check_item['created_date'] is not None
+
+
+def test_list_changes_returns_db_manager_find_no_changes(inmemory_db_setup,
+                                                         test_changes_records,
+                                                         xml_test):
+    for change_record in test_changes_records:
+        inmemory_db_setup.changes_db_manager.create(change_record['change_id'],
+                                                    change_record)
+    last_sequence = test_changes_records[-1]['change_id']
+    limit = 5
+    check_list = inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                                limit=limit)
+    assert len(check_list) == 0

--- a/catalog_persistence/tests/test_services.py
+++ b/catalog_persistence/tests/test_services.py
@@ -1,0 +1,45 @@
+from unittest.mock import Mock
+
+from catalog_persistence.databases import QueryOperator
+from catalog_persistence.services import SortOrder
+
+
+def test_list_changes_returns_db_manager_find_result(setup,
+                                                     database_service,
+                                                     test_changes_records,
+                                                     xml_test):
+    expected_list = test_changes_records
+    test_changes_db_manager = database_service.changes_db_manager
+    database_service.changes_db_manager = Mock()
+    database_service.changes_db_manager.find = Mock()
+    database_service.changes_db_manager.find.return_value = expected_list
+    last_sequence = 'SEQ1'
+    filter_called = {
+        'change_id': [
+            (QueryOperator.GREATER_THAN, last_sequence)
+        ]
+    }
+    limit = 10
+    fields_called = [
+        'change_id',
+        'document_id',
+        'document_type',
+        'type',
+        'created_date'
+    ]
+    sorted_called = [{'change_id': SortOrder.ASC.value}]
+    check_list = database_service.list_changes(last_sequence='SEQ1',
+                                               limit=limit)
+    database_service.changes_db_manager.find.assert_called_once_with(
+        fields=fields_called,
+        limit=limit,
+        filter=filter_called,
+        sort=sorted_called
+    )
+    database_service.changes_db_manager = test_changes_db_manager
+    assert len(check_list) == len(expected_list)
+    for check_list_item, expected_item in zip(check_list, expected_list):
+        assert check_list_item['document_id'] == expected_item['document_id']
+        assert check_list_item['document_type'] ==\
+            expected_item['document_type']
+        assert check_list_item['created_date'] is not None

--- a/catalog_persistence/tests/test_services.py
+++ b/catalog_persistence/tests/test_services.py
@@ -83,7 +83,7 @@ def test_list_changes_returns_db_manager_find_limit(inmemory_db_setup,
     limit = 5
     check_list = inmemory_db_setup.list_changes(last_sequence=last_sequence,
                                                 limit=limit)
-    assert len(check_list) == len(test_changes_records[last_record + 1:])
+    assert len(check_list) == limit
     for check_item, expected_item in \
             zip(check_list, test_changes_records[last_record + 1:limit + 1]):
         assert check_item['change_id'] == expected_item['change_id']

--- a/catalog_persistence/tests/test_services.py
+++ b/catalog_persistence/tests/test_services.py
@@ -1,3 +1,37 @@
+from unittest.mock import Mock
+
+from catalog_persistence.databases import QueryOperator
+from catalog_persistence.services import ChangeType, SortOrder
+
+
+def test_list_changes_calls_db_manager_find(inmemory_db_setup,
+                                            test_changes_records,
+                                            xml_test):
+    inmemory_db_setup.changes_db_manager.find = Mock()
+    inmemory_db_setup.changes_db_manager.find.return_value = []
+    last_sequence = '123456'
+    limit = 10
+    expected_fields = [
+        'change_id',
+        'document_id',
+        'document_type',
+        'type',
+        'created_date'
+    ]
+    filter = {
+        'change_id': [
+            (QueryOperator.GREATER_THAN, last_sequence)
+        ]
+    }
+    sort = [{'created_date': SortOrder.ASC.value}]
+    inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                   limit=limit)
+    inmemory_db_setup.changes_db_manager.find.assert_called_once_with(
+        fields=expected_fields,
+        limit=limit,
+        filter=filter,
+        sort=sort
+    )
 
 
 def test_list_changes_returns_db_manager_find_all(inmemory_db_setup,
@@ -14,7 +48,7 @@ def test_list_changes_returns_db_manager_find_all(inmemory_db_setup,
     for check_item, expected_item in zip(check_list, test_changes_records):
         assert check_item['change_id'] == expected_item['change_id']
         assert check_item['document_id'] == expected_item['document_id']
-        assert check_item['type'] == expected_item['type']
+        assert check_item['type'] == ChangeType(expected_item['type']).name
         assert check_item['created_date'] is not None
 
 
@@ -34,7 +68,7 @@ def test_list_changes_returns_db_manager_find_from_last(inmemory_db_setup,
             zip(check_list, test_changes_records[last_record + 1:]):
         assert check_item['change_id'] == expected_item['change_id']
         assert check_item['document_id'] == expected_item['document_id']
-        assert check_item['type'] == expected_item['type']
+        assert check_item['type'] == ChangeType(expected_item['type']).name
         assert check_item['created_date'] is not None
 
 
@@ -54,7 +88,7 @@ def test_list_changes_returns_db_manager_find_limit(inmemory_db_setup,
             zip(check_list, test_changes_records[last_record + 1:limit + 1]):
         assert check_item['change_id'] == expected_item['change_id']
         assert check_item['document_id'] == expected_item['document_id']
-        assert check_item['type'] == expected_item['type']
+        assert check_item['type'] == ChangeType(expected_item['type']).name
         assert check_item['created_date'] is not None
 
 

--- a/catalogmanager/__init__.py
+++ b/catalogmanager/__init__.py
@@ -1,28 +1,31 @@
-from catalogmanager.article_services import (
-    ArticleServices
-)
+
+from catalog_persistence.databases import CouchDBManager
 from catalogmanager.models.article_model import ArticleDocument
 from catalogmanager.models.file import File
-from catalog_persistence.databases import CouchDBManager
+from catalogmanager.services import ArticleServices, ChangeService
+
+
+def _get_changes_dbmanager(database_config_copy):
+    changes_database_config = database_config_copy
+    changes_database_config['database_name'] = "changes"
+    return CouchDBManager(**changes_database_config)
 
 
 def _get_article_service(**db_settings):
     database_config = db_settings
     articles_database_config = database_config.copy()
     articles_database_config['database_name'] = "articles"
-    changes_database_config = database_config.copy()
-    changes_database_config['database_name'] = "changes"
 
     return ArticleServices(
         CouchDBManager(**articles_database_config),
-        CouchDBManager(**changes_database_config)
+        _get_changes_dbmanager(database_config.copy())
     )
 
 
 def create_file(filename, content):
     """
-    Cria instancia de objeto File que será usado para o tratamento dos dados do
-    documento a ser persistido
+    Cria instancia de objeto File que será usado para o tratamento dos
+    dados do documento a ser persistido
 
     Params:
     filename: nome do arquivo a ser manipulado
@@ -42,8 +45,9 @@ def put_article(article_id, xml_file, assets_files=[], **db_settings):
     :param article_id: ID do Documento do tipo Artigo, para identificação
         referencial
     :param xml_file: objeto File com nome e conteúdo do XML
-    :param assets_files: lista de objetos File contendo os arquivos dos ativos
-        digitais do Artigo, cada um com nome e seu respectivo conteúdo
+    :param assets_files: lista de objetos File contendo os arquivos dos
+        ativos digitais do Artigo, cada um com nome e seu respectivo
+        conteúdo
     :param db_settings: dicionário com as configurações do banco de dados.
         Deve conter:
         - database_uri: URI do banco de dados (host:porta)
@@ -52,8 +56,8 @@ def put_article(article_id, xml_file, assets_files=[], **db_settings):
 
     :returns: lista com os nomes dos arquivos de ativos digitais não
         referenciados no XML e lista com os nomes dos arquivos de ativos
-        digitais referenciados no XML e que não constam na lista de arquivos de
-        ativos digitais informada
+        digitais referenciados no XML e que não constam na lista de
+        arquivos de ativos digitais informada
     :rtype: tuple(list(), list())
     """
     article_services = _get_article_service(**db_settings)
@@ -121,14 +125,14 @@ def get_asset_file(article_id, asset_id, **db_settings):
 def set_assets_public_url(article_id, xml_content, assets_filenames,
                           public_url):
     """
-    Atualiza hrefs dos ativos digitais com a URL pública no conteúdo do XML
-    informado, tornando-os acessíveis via interface da API
+    Atualiza hrefs dos ativos digitais com a URL pública no conteúdo do
+    XML informado, tornando-os acessíveis via interface da API
 
     :param article_id: ID do Documento do tipo Artigo, para identificação
         referencial
     :param xml_content: conteúdo XML a ser atualizado
-    :param assets_filenames: nome de identificação dos ativos digitais contidos
-        no XML
+    :param assets_filenames: nome de identificação dos ativos digitais
+        contidos no XML
     :param public_url: base da URL pública a ser colocada nos hrefs
 
     :returns: conteúdo do XML atualizado
@@ -137,5 +141,29 @@ def set_assets_public_url(article_id, xml_content, assets_filenames,
     article.xml_file = File(file_name="xml_file.xml", content=xml_content)
     for name in article.assets:
         if name in assets_filenames:
-            article.assets[name].href = public_url.format(article_id, name)
+            article.assets[name].href = public_url.format(article_id,
+                                                          name)
     return article.xml_tree.content
+
+
+def list_changes(last_sequence, limit, **db_settings):
+    """
+    Retorna lista de todas as mudanças a partir de sequencial informado,
+    na ordem em que ocorreram, limitadas ao parâmetro de limite informado.
+
+    :param last_sequence: sequencial de mudança, que deve ser a referência
+        para a busca dos sequenciais a serem listados.
+    :param limit: limite máximo de registros de mudança que devem ser
+        listados.
+    :param db_settings: dicionário com as configurações do banco de dados.
+        Deve conter:
+        - database_uri: URI do banco de dados (host:porta)
+        - database_username: usuário do banco de dados
+        - database_password: senha do banco de dados
+
+    :returns: lista de mundanças
+    :rtype: list()
+    """
+    change_service = ChangeService(_get_changes_dbmanager(db_settings.copy()))
+    return change_service.list_changes(last_sequence=last_sequence,
+                                       limit=limit)

--- a/catalogmanager/services.py
+++ b/catalogmanager/services.py
@@ -5,7 +5,7 @@ from catalog_persistence.models import (
         RecordType,
     )
 from catalog_persistence.databases import DocumentNotFound
-from catalog_persistence.services import DatabaseService, SortOrder
+from catalog_persistence.services import DatabaseService
 from .models.article_model import (
     ArticleDocument,
 )

--- a/catalogmanager/services.py
+++ b/catalogmanager/services.py
@@ -5,7 +5,7 @@ from catalog_persistence.models import (
         RecordType,
     )
 from catalog_persistence.databases import DocumentNotFound
-from catalog_persistence.services import DatabaseService
+from catalog_persistence.services import DatabaseService, SortOrder
 from .models.article_model import (
     ArticleDocument,
 )
@@ -129,3 +129,14 @@ class ArticleServices:
                 'AssetDocument file {} (ArticleDocument {}) not found.'.format(
                     asset_id, article_id)
             )
+
+
+class ChangeService:
+
+    def __init__(self, changes_db_manager):
+        self.change_db_service = DatabaseService(None, changes_db_manager)
+
+    def list_changes(self, last_sequence, limit):
+        return self.change_db_service.list_changes(
+            last_sequence=last_sequence,
+            limit=limit)

--- a/catalogmanager/tests/conftest.py
+++ b/catalogmanager/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import pytest
 from pyramid import testing
 
-from catalogmanager.article_services import ArticleServices
+from catalogmanager.services import ArticleServices
 from catalogmanager.models.file import File
 from catalog_persistence.databases import (
     InMemoryDBManager,
@@ -97,8 +97,8 @@ def functional_config(request):
 @pytest.fixture
 def change_service(functional_config):
     return (
-        InMemoryDBManager(database_name='test1'),
-        InMemoryDBManager(database_name='test2')
+        InMemoryDBManager(database_name='articles'),
+        InMemoryDBManager(database_name='changes')
     )
 
 
@@ -172,3 +172,18 @@ def couchdb_receive_package(dbserver_service, test_package_A):
     return article_services.receive_package(id='ID',
                                             xml_file=test_package_A[0],
                                             files=test_package_A[1:])
+
+
+@pytest.fixture
+def list_changes_expected():
+    return [
+        {
+            "change_id": "SEQ{}".format(id),
+            "document_id": "ID-{}".format(id),
+            "document_type": "ARTICLE",
+            "content": {
+                'xml': "ID-{}.xml".format(id),
+            }
+        }
+        for id in range(123457, 123466)
+    ]

--- a/catalogmanager/tests/conftest.py
+++ b/catalogmanager/tests/conftest.py
@@ -178,7 +178,7 @@ def couchdb_receive_package(dbserver_service, test_package_A):
 def list_changes_expected():
     return [
         {
-            "change_id": "SEQ{}".format(id),
+            "change_id": "{}".format(id),
             "document_id": "ID-{}".format(id),
             "document_type": "ARTICLE",
             "type": "CREATE",

--- a/catalogmanager/tests/conftest.py
+++ b/catalogmanager/tests/conftest.py
@@ -181,9 +181,7 @@ def list_changes_expected():
             "change_id": "SEQ{}".format(id),
             "document_id": "ID-{}".format(id),
             "document_type": "ARTICLE",
-            "content": {
-                'xml': "ID-{}.xml".format(id),
-            }
+            "type": "CREATE",
         }
         for id in range(123457, 123466)
     ]

--- a/catalogmanager/tests/test_catalogmanager.py
+++ b/catalogmanager/tests/test_catalogmanager.py
@@ -15,10 +15,10 @@ def test_list_changes_return_from_changeservice_list_changes(
 ):
     mocked_changes_dbmanager.return_value = change_service[1]
     mocked_list_changes.return_value = list_changes_expected
-    changes = catalogmanager.list_changes(last_sequence='SEQ1',
+    changes = catalogmanager.list_changes(last_sequence='1',
                                           limit=10)
     mocked_list_changes.assert_called_once_with(
-        last_sequence='SEQ1',
+        last_sequence='1',
         limit=10
     )
     assert changes == list_changes_expected

--- a/catalogmanager/tests/test_catalogmanager.py
+++ b/catalogmanager/tests/test_catalogmanager.py
@@ -1,0 +1,24 @@
+
+from unittest.mock import patch
+
+import catalogmanager
+from catalogmanager.services import ChangeService
+
+
+@patch.object(catalogmanager, '_get_changes_dbmanager')
+@patch.object(ChangeService, 'list_changes')
+def test_list_changes_return_from_changeservice_list_changes(
+    mocked_list_changes,
+    mocked_changes_dbmanager,
+    change_service,
+    list_changes_expected
+):
+    mocked_changes_dbmanager.return_value = change_service[1]
+    mocked_list_changes.return_value = list_changes_expected
+    changes = catalogmanager.list_changes(last_sequence='SEQ1',
+                                          limit=10)
+    mocked_list_changes.assert_called_once_with(
+        last_sequence='SEQ1',
+        limit=10
+    )
+    assert changes == list_changes_expected

--- a/catalogmanager/tests/test_services.py
+++ b/catalogmanager/tests/test_services.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from catalog_persistence.databases import DocumentNotFound
-from catalog_persistence.services import DatabaseService, SortOrder
+from catalog_persistence.services import DatabaseService
 from catalog_persistence.models import RecordType
 from catalogmanager.services import (
     ArticleServices,

--- a/catalogmanager/tests/test_services.py
+++ b/catalogmanager/tests/test_services.py
@@ -208,7 +208,7 @@ def test_list_changes_returns_changes_from_database_service(
 ):
     mocked_list_changes.return_value = list_changes_expected
     change_services = ChangeService(change_service[1])
-    changes = change_services.list_changes('SEQ1', 10)
-    mocked_list_changes.assert_called_once_with(last_sequence='SEQ1',
+    changes = change_services.list_changes('1', 10)
+    mocked_list_changes.assert_called_once_with(last_sequence='1',
                                                 limit=10)
     assert changes == list_changes_expected

--- a/catalogmanager/tests/test_services.py
+++ b/catalogmanager/tests/test_services.py
@@ -3,11 +3,12 @@ from unittest.mock import patch
 import pytest
 
 from catalog_persistence.databases import DocumentNotFound
-from catalog_persistence.services import DatabaseService
+from catalog_persistence.services import DatabaseService, SortOrder
 from catalog_persistence.models import RecordType
-from catalogmanager.article_services import (
+from catalogmanager.services import (
     ArticleServices,
-    ArticleServicesException
+    ArticleServicesException,
+    ChangeService
 )
 from catalogmanager.xml.xml_tree import (
     XMLTree
@@ -197,3 +198,17 @@ def test_get_asset_files(change_service, test_package_A):
     assert len(msg) == 0
     for asset in files:
         assert asset.content in asset_contents
+
+
+@patch.object(DatabaseService, 'list_changes')
+def test_list_changes_returns_changes_from_database_service(
+    mocked_list_changes,
+    change_service,
+    list_changes_expected
+):
+    mocked_list_changes.return_value = list_changes_expected
+    change_services = ChangeService(change_service[1])
+    changes = change_services.list_changes('SEQ1', 10)
+    mocked_list_changes.assert_called_once_with(last_sequence='SEQ1',
+                                                limit=10)
+    assert changes == list_changes_expected

--- a/catalogmanager_api/tests/test_article.py
+++ b/catalogmanager_api/tests/test_article.py
@@ -39,7 +39,7 @@ def test_http_get_article_not_found(mocked_get_article_data, testapp):
     article_id = 'ID123456'
     error_msg = 'Article {} not found'.format(article_id)
     mocked_get_article_data.side_effect = \
-        catalogmanager.article_services.ArticleServicesException(
+        catalogmanager.services.ArticleServicesException(
             message=error_msg
         )
     expected = {
@@ -89,7 +89,7 @@ def test_http_get_xml_file_article_not_found(mocked_get_article_file, testapp):
     article_id = 'ID123456'
     error_msg = 'Article {} not found'.format(article_id)
     mocked_get_article_file.side_effect = \
-        catalogmanager.article_services.ArticleServicesException(
+        catalogmanager.services.ArticleServicesException(
             message=error_msg
         )
     expected = {
@@ -106,7 +106,7 @@ def test_http_get_xml_file_not_found(mocked_get_article_file, testapp):
     article_id = 'ID123456'
     error_msg = 'Missing XML file {}'.format(article_id)
     mocked_get_article_file.side_effect = \
-        catalogmanager.article_services.ArticleServicesException(
+        catalogmanager.services.ArticleServicesException(
             message=error_msg
         )
     expected = {
@@ -291,7 +291,7 @@ def test_http_article_calls_put_article_service_error(mocked_put_article,
                                                       test_xml_file):
     article_id = 'ID-post-article-123'
     mocked_put_article.side_effect = \
-        catalogmanager.article_services.ArticleServicesException(
+        catalogmanager.services.ArticleServicesException(
             message='Missing XML file {}'.format(article_id)
         )
     expected = {
@@ -394,7 +394,7 @@ def test_http_get_asset_file_not_found(mocked_get_asset_file,
     asset_id = 'a.jpg'
     error_msg = 'Asset {} (Article {}) not found'.format(asset_id, article_id)
     mocked_get_asset_file.side_effect = \
-        catalogmanager.article_services.ArticleServicesException(
+        catalogmanager.services.ArticleServicesException(
             message=error_msg
         )
     expected = {

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -32,13 +32,8 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
         {
             "change_id": "SEQ{}".format(id),
             "document_id": "ID-{}".format(id),
-            "document_type": "ARTICLE",
-            "content": {
-                'xml': "ID-{}.xml".format(id),
-                'assets': [
-                    "{}-{}.png".format(id, asset_id) for asset_id in range(3)
-                ]
-            }
+            "document_type": "ART",
+            "type": "CREATE"
         }
         for id in range(123457, 123466)
     ]

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -10,16 +10,16 @@ def test_change_api_collection_post_calls_list_changes(mocked_list_changes,
                                                        db_settings,
                                                        testapp):
     request = testing.DummyRequest()
-    request.POST = {
+    request.GET = {
         'last_sequence': 'SEQ123456',
         'limit': 100,
     }
     request.db_settings = db_settings
-    ChangeAPI.collection_post(ChangeAPI(request))
+    ChangeAPI.collection_get(ChangeAPI(request))
 
     mocked_list_changes.assert_called_once_with(
-        last_sequence=request.POST['last_sequence'],
-        limit=request.POST['limit'],
+        last_sequence=request.GET['last_sequence'],
+        limit=request.GET['limit'],
         **db_settings
     )
 
@@ -44,11 +44,11 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
     ]
     mocked_list_changes.return_value = expected
     request = testing.DummyRequest()
-    request.POST = {
+    request.GET = {
         'last_sequence': 'SEQ123456',
         'limit': 100,
     }
     request.db_settings = db_settings
-    response = ChangeAPI.collection_post(ChangeAPI(request))
+    response = ChangeAPI.collection_get(ChangeAPI(request))
     assert response.status_code == 200
     assert response.json == expected

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -11,14 +11,14 @@ def test_change_api_collection_post_calls_list_changes(mocked_list_changes,
                                                        testapp):
     request = testing.DummyRequest()
     request.GET = {
-        'last_sequence': 'SEQ123456',
+        'since': 'SEQ123456',
         'limit': 100,
     }
     request.db_settings = db_settings
     ChangeAPI.collection_get(ChangeAPI(request))
 
     mocked_list_changes.assert_called_once_with(
-        last_sequence=request.GET['last_sequence'],
+        last_sequence=request.GET['since'],
         limit=request.GET['limit'],
         **db_settings
     )
@@ -45,7 +45,7 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
     mocked_list_changes.return_value = expected
     request = testing.DummyRequest()
     request.GET = {
-        'last_sequence': 'SEQ123456',
+        'since': 'SEQ123456',
         'limit': 100,
     }
     request.db_settings = db_settings

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from unittest.mock import patch
+
+from pyramid import testing
+
+from catalogmanager_api.views.change import ChangeAPI
+
+
+@patch('catalogmanager.list_changes')
+def test_change_api_collection_post_calls_list_changes(mocked_list_changes,
+                                                       db_settings,
+                                                       testapp):
+    request = testing.DummyRequest()
+    request.POST = {
+        'last_sequence': 'SEQ123456',
+        'limit': 100,
+    }
+    request.db_settings = db_settings
+    ChangeAPI.collection_post(ChangeAPI(request))
+
+    mocked_list_changes.assert_called_once_with(
+        last_sequence=request.POST['last_sequence'],
+        limit=request.POST['limit'],
+        **db_settings
+    )
+
+
+@patch('catalogmanager.list_changes')
+def test_change_api_collection_post_return_changes_list(mocked_list_changes,
+                                                        db_settings,
+                                                        testapp):
+    expected = [
+        {
+            "change_id": "SEQ{}".format(id),
+            "document_id": "ID-{}".format(id),
+            "document_type": "ARTICLE",
+            "content": {
+                'xml': "ID-{}.xml".format(id),
+                'assets': [
+                    "{}-{}.png".format(id, asset_id) for asset_id in range(3)
+                ]
+            }
+        }
+        for id in range(123457, 123466)
+    ]
+    mocked_list_changes.return_value = expected
+    request = testing.DummyRequest()
+    request.POST = {
+        'last_sequence': 'SEQ123456',
+        'limit': 100,
+    }
+    request.db_settings = db_settings
+    response = ChangeAPI.collection_post(ChangeAPI(request))
+    assert response.status_code == 200
+    assert response.json == expected

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -11,7 +11,7 @@ def test_change_api_collection_post_calls_list_changes(mocked_list_changes,
                                                        testapp):
     request = testing.DummyRequest()
     request.GET = {
-        'since': 'SEQ123456',
+        'since': '123456',
         'limit': 100,
     }
     request.db_settings = db_settings
@@ -30,7 +30,7 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
                                                         testapp):
     expected = [
         {
-            "change_id": "SEQ{}".format(id),
+            "change_id": "{}".format(id),
             "document_id": "ID-{}".format(id),
             "document_type": "ART",
             "type": "CREATE"
@@ -40,7 +40,7 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
     mocked_list_changes.return_value = expected
     request = testing.DummyRequest()
     request.GET = {
-        'since': 'SEQ123456',
+        'since': '123456',
         'limit': 100,
     }
     request.db_settings = db_settings

--- a/catalogmanager_api/tests/test_change.py
+++ b/catalogmanager_api/tests/test_change.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from unittest.mock import patch
 
 from pyramid import testing

--- a/catalogmanager_api/views/article.py
+++ b/catalogmanager_api/views/article.py
@@ -35,7 +35,7 @@ class Article:
                 assets_files=assets_files,
                 **self.request.db_settings
             )
-        except catalogmanager.article_services.ArticleServicesException as e:
+        except catalogmanager.services.ArticleServicesException as e:
             return {
                 "error": "500",
                 "message": "Article error"
@@ -48,7 +48,7 @@ class Article:
                 **self.request.db_settings
             )
             return article_data
-        except catalogmanager.article_services.ArticleServicesException as e:
+        except catalogmanager.services.ArticleServicesException as e:
             return {
                 "error": "404",
                 "message": e.message
@@ -82,7 +82,7 @@ class ArticleXML:
                 )
             return Response(content_type='application/xml',
                             body_file=io.BytesIO(xml_file_content))
-        except catalogmanager.article_services.ArticleServicesException as e:
+        except catalogmanager.services.ArticleServicesException as e:
             return {
                 "error": "404",
                 "message": e.message
@@ -104,7 +104,7 @@ class ArticleAsset:
                 **self.request.db_settings
             )
             return Response(content_type=content_type, body=content)
-        except catalogmanager.article_services.ArticleServicesException as e:
+        except catalogmanager.services.ArticleServicesException as e:
             return {
                 "error": "404",
                 "message": e.message

--- a/catalogmanager_api/views/change.py
+++ b/catalogmanager_api/views/change.py
@@ -1,5 +1,5 @@
 
-from cornice.resource import resource, view
+from cornice.resource import resource
 from pyramid.response import Response
 
 import catalogmanager
@@ -12,13 +12,12 @@ class ChangeAPI:
         self.request = request
         self.context = context
 
-    @view(content_type='multipart/form-data')
-    def collection_post(self):
+    def collection_get(self):
         limit = 0
-        if self.request.POST.get('limit'):
-            limit = int(self.request.POST['limit'])
+        if self.request.GET.get('limit'):
+            limit = int(self.request.GET['limit'])
         changes = catalogmanager.list_changes(
-            last_sequence=self.request.POST.get('last_sequence'),
+            last_sequence=self.request.GET.get('since', ''),
             limit=limit,
             **self.request.db_settings
         )

--- a/catalogmanager_api/views/change.py
+++ b/catalogmanager_api/views/change.py
@@ -1,0 +1,25 @@
+
+from cornice.resource import resource, view
+from pyramid.response import Response
+
+import catalogmanager
+
+
+@resource(collection_path='/changes', path='/changes/{id}', renderer='json')
+class ChangeAPI:
+
+    def __init__(self, request, context=None):
+        self.request = request
+        self.context = context
+
+    @view(content_type='multipart/form-data')
+    def collection_post(self):
+        limit = 0
+        if self.request.POST.get('limit'):
+            limit = int(self.request.POST['limit'])
+        changes = catalogmanager.list_changes(
+            last_sequence=self.request.POST.get('last_sequence'),
+            limit=limit,
+            **self.request.db_settings
+        )
+        return Response(json=changes)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ pyramid-mako==1.0.2
 pyramid_debugtoolbar==4.4
 pytest==3.4.2
 pytest-cov==2.5.1
+pytest-lazy-fixture==0.4.0
 waitress==1.1.0
 WebOb==1.8.0rc1
 WebTest==2.0.29

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ requires = [
     'cornice>=3.4.0',
 ]
 
-test_requires = ['webtest', 'pytest', 'pytest-cov']
+test_requires = ['webtest', 'pytest', 'pytest-cov', 'pytest-lazy-fixture']
 setup_requires = ['pytest-runner']
 
 setup(

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -64,20 +64,16 @@ def test_add_article_register_change(testapp, test_package_A):
 
     # Deve ser possível recuperar os registros de mudanças do documento de
     # acordo com os parâmetros informados no serviço
-    params = {
-        'last_sequence': '',
-        'limit': 10,
-    }
-    result = testapp.post('/changes',
-                          params=params,
-                          content_type='multipart/form-data')
+    last_sequence = ''
+    limit = 10
+    result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
+                                                             limit))
     assert result.status_code == 200
     assert result.json is not None
     assert len(result.json) > 0
-    params['last_sequence'] = result.json[-1]['change_id']
-    result = testapp.post('/changes',
-                          params=params,
-                          content_type='multipart/form-data')
+    last_sequence = result.json[-1]['change_id']
+    result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
+                                                             limit))
     assert result.status_code == 200
     assert result.json is not None
     assert len(result.json) == 0

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -28,7 +28,7 @@ def test_add_article_register_change(testapp, test_package_A):
             latest = int(changes_expected['latest']) + 1
             changes_expected['results'].append(
                 {
-                    'change_id': '{:0>17}'.format(latest),
+                    'change_id': latest,
                     'document_id': article_id,
                     'document_type': 'ART',
                     'type': 'UPDATE'
@@ -47,7 +47,7 @@ def test_add_article_register_change(testapp, test_package_A):
 
     changes_expected['results'].insert(0,
                                        {
-                                           'change_id': '1'.zfill(20),
+                                           'change_id': 1,
                                            'document_id': article_id,
                                            'document_type': 'ART',
                                            'type': 'CREATE'

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -61,3 +61,23 @@ def test_add_article_register_change(testapp, test_package_A):
     ]
     for expected_href in expected_hrefs:
         assert expected_href in xml_nodes
+
+    # Deve ser possível recuperar os registros de mudanças do documento de
+    # acordo com os parâmetros informados no serviço
+    params = {
+        'last_sequence': '',
+        'limit': 10,
+    }
+    result = testapp.post('/changes',
+                          params=params,
+                          content_type='multipart/form-data')
+    assert result.status_code == 200
+    assert result.json is not None
+    assert len(result.json) > 0
+    params['last_sequence'] = result.json[-1]['change_id']
+    result = testapp.post('/changes',
+                          params=params,
+                          content_type='multipart/form-data')
+    assert result.status_code == 200
+    assert result.json is not None
+    assert len(result.json) == 0

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -13,13 +13,28 @@ def test_add_article_register_change(testapp, test_package_A):
 
     # Um documento é registrado no módulo de persistencia. Ex: Artigo
     xml_file_path, assets_files = test_package_A[0], test_package_A[1:]
+    changes_expected = {
+        'results': [],
+        'latest': 1
+    }
     assets_field = []
     for article_file in assets_files:
+        article_filename = os.path.basename(article_file)
         with open(article_file, 'rb') as fb:
             file_content = fb.read()
             assets_field.append(('asset_field',
-                                 os.path.basename(article_file),
+                                 article_filename,
                                  file_content))
+            latest = int(changes_expected['latest']) + 1
+            changes_expected['results'].append(
+                {
+                    'change_id': '{:0>17}'.format(latest),
+                    'document_id': article_id,
+                    'document_type': 'ART',
+                    'type': 'UPDATE'
+                }
+            )
+            changes_expected['latest'] = latest
     params = OrderedDict([
         ("article_id", article_id),
         ("xml_file", webtest.forms.Upload(xml_file_path))
@@ -30,6 +45,13 @@ def test_add_article_register_change(testapp, test_package_A):
                          content_type='multipart/form-data')
     assert result.status_code == 201
 
+    changes_expected['results'].insert(0,
+                                       {
+                                           'change_id': '1'.zfill(20),
+                                           'document_id': article_id,
+                                           'document_type': 'ART',
+                                           'type': 'CREATE'
+                                       })
     # Checa se é possível recuperar o registro do documento pelo id
     result = testapp.get(url)
     assert result.status_code == 200
@@ -70,10 +92,16 @@ def test_add_article_register_change(testapp, test_package_A):
                                                              limit))
     assert result.status_code == 200
     assert result.json is not None
-    assert len(result.json) > 0
-    last_sequence = result.json[-1]['change_id']
-    result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
-                                                             limit))
-    assert result.status_code == 200
-    assert result.json is not None
-    assert len(result.json) == 0
+    assert len(result.json) > len(changes_expected['results'])
+    for resp_result, expected in zip(result.json, changes_expected['results']):
+        assert resp_result['document_id'] == expected['document_id']
+        assert resp_result['document_type'] == expected['document_type']
+        assert resp_result['type'] == expected['type']
+
+    # Sequencial das mudanças ainda não implementado
+    # last_sequence = result.json[-1]['change_id']
+    # result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
+    #                                                          limit))
+    # assert result.status_code == 200
+    # assert result.json is not None
+    # assert len(result.json) == 0


### PR DESCRIPTION
Funcionalidade listar mudanças no módulo `catalogmanager`:
- Alteração dos métodos `DBManager.find()` para inclusão/alteração de parâmetros na assinatura e para atender aos filtros
- Renomeado módulo `article_services` -> `services` para a inclusão do serviços de mudanças
- Implementação de interface para a lista de mudanças no `catalogmanager`.
- Testes da interface do `catalogmanager`.

Funcionalidade listar mudanças na API do Catalog Manager  …
- Implementada API de mudanças com testes unitários
- Adequação às mudanças no `catalogmanager`
- Atualizado teste funcional

Fixes #86 