### PR TITLE
Ajuste nas mudanças p/ listar ordenadamente pelo ID

### DIFF
--- a/persistence/services.py
+++ b/persistence/services.py
@@ -36,21 +36,22 @@ class ChangesService:
                         document_record,
                         change_type,
                         attachment_id=None):
+        sequencial = self.seqnum_generator.new()
         change_record = {
-            'change_id': uuid4().hex,
+            'change_id': sequencial,
             'document_id': document_record['document_id'],
             'document_type': document_record['document_type'],
             'type': change_type.value,
             'created_date': str(datetime.utcnow().timestamp()),
-            'seqnum': self.seqnum_generator.new(),
+            'record_id': str(sequencial),
         }
         if attachment_id:
             change_record.update({'attachment_id': attachment_id})
         self.changes_db_manager.create(
-            change_record['change_id'],
+            change_record['record_id'],
             change_record
         )
-        return change_record['change_id']
+        return change_record['record_id']
 
 
 class DatabaseService:
@@ -248,10 +249,11 @@ class DatabaseService:
         ]
         filter = {
             'change_id': [
-                (QueryOperator.GREATER_THAN, last_sequence)
+                (QueryOperator.GREATER_THAN,
+                 last_sequence if last_sequence else None)
             ]
         }
-        sort = [{'created_date': SortOrder.ASC.value}]
+        sort = [{'change_id': SortOrder.ASC.value}]
         changes = self.changes_service.changes_db_manager.find(
                                                fields=fields,
                                                limit=limit,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,7 @@ def testapp(request, db_settings):
                                           db_settings['password'])
         try:
             db_server.delete('changes')
+            db_server.delete('changes_seqnum')
             db_server.delete('articles')
         except couchdb.http.ResourceNotFound:
             pass

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -98,10 +98,9 @@ def test_add_article_register_change(testapp, test_package_A):
         assert resp_result['document_type'] == expected['document_type']
         assert resp_result['type'] == expected['type']
 
-    # Sequencial das mudanças ainda não implementado
-    # last_sequence = result.json[-1]['change_id']
-    # result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
-    #                                                          limit))
-    # assert result.status_code == 200
-    # assert result.json is not None
-    # assert len(result.json) == 0
+    last_sequence = result.json[-1]['change_id']
+    result = testapp.get('/changes?since={}&limit={}'.format(last_sequence,
+                                                             limit))
+    assert result.status_code == 200
+    assert result.json is not None
+    assert len(result.json) == 0


### PR DESCRIPTION
Por conta da implementação do sequencial para as mudanças, foi necessário adaptar a listagem das mudanças e o ajuste dos testes.

Closes #5 