### PR TITLE
[tk109] Implementar as métricas com o Prometheus

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -8,6 +8,9 @@ from pyramid.paster import get_appsettings
 from pyramid.response import Response
 from pyramid.view import view_config, notfound_view_config
 
+from prometheus_client import generate_latest
+
+
 import logging
 
 LOGGER = logging.getLogger(__name__)
@@ -29,6 +32,14 @@ def openAPI_spec(request):
 @view_config(route_name='home')
 def home(request):
     return Response('')
+
+
+@view_config(route_name='metrics')
+def metrics(request):
+    return Response(
+        body=generate_latest(),
+        charset='utf-8',
+        content_type='text/plain')
 
 
 @notfound_view_config()
@@ -58,10 +69,10 @@ def main(global_config, **settings):
             }
         }
     )
-
     config.include(includeme)
 
     config.add_route('home', '/')
+    config.add_route('metrics', '/metrics')
 
     def couchdb_settings(request):
         ini_settings = get_appsettings(global_config['__file__'])

--- a/api/views/article.py
+++ b/api/views/article.py
@@ -8,8 +8,23 @@ from pyramid.httpexceptions import (
         )
 from pyramid.response import Response
 from cornice.resource import resource
+from prometheus_client import Summary
 
 import managers
+
+
+REQUEST_TIME_API_ARTICLE_GET = Summary(
+    'api_article_get_request_processing_seconds',
+    'Time spent processing api article get')
+REQUEST_TIME_API_XML_GET = Summary(
+    'api_xml_get_request_processing_seconds',
+    'Time spent processing api xml get ')
+REQUEST_TIME_API_ASSET_GET = Summary(
+    'api_asset_get_request_processing_seconds',
+    'Time spent processing api asset get ')
+REQUEST_TIME_API_ARTICLE_PUT = Summary(
+    'api_article_put_request_processing_seconds',
+    'Time spent processing api article put')
 
 
 @resource(collection_path='/articles', path='/articles/{id}', renderer='json',
@@ -26,6 +41,7 @@ class Article:
         return managers.create_file(filename=file_path.name,
                                     content=content)
 
+    @REQUEST_TIME_API_ARTICLE_PUT.time()
     def put(self):
         """Receive Article document package which must contain a XML file and
         assets files referenced."""
@@ -55,6 +71,7 @@ class Article:
         else:
             raise HTTPCreated()
 
+    @REQUEST_TIME_API_ARTICLE_GET.time()
     def get(self):
         """Returns Article document metadata."""
         try:
@@ -74,6 +91,7 @@ class ArticleXML:
         self.request = request
         self.context = context
 
+    @REQUEST_TIME_API_XML_GET.time()
     def get(self):
         """Returns XML Article file with updated public URLs to its assets."""
         try:
@@ -106,6 +124,7 @@ class ArticleAsset:
         self.request = request
         self.context = context
 
+    @REQUEST_TIME_API_ASSET_GET.time()
     def get(self):
         """Returns Asset file."""
         try:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,3 +23,4 @@ services:
     labels:
       io.rancher.container.pull_image: always
       io.rancher.container.start_once: 'true'
+

--- a/persistence/services.py
+++ b/persistence/services.py
@@ -6,12 +6,27 @@ from prometheus_client import Summary
 from .databases import QueryOperator
 
 
-REQUEST_TIME_UPD_CHANGE = Summary(
-    'request_processing_upd_chg_seconds', 'Time spent processing upd change')
-REQUEST_TIME_UPD_DOC = Summary(
-    'request_processing_upd_doc_seconds', 'Time spent processing upd doc')
-REQUEST_TIME_UPD_ATT = Summary(
-    'request_processing_upd_att_seconds', 'Time spent processing upd att')
+REQUEST_TIME_CHANGES_UPD = Summary(
+    'changes_service_upd_request_processing_seconds',
+    'Time spent processing changes service upd ')
+REQUEST_TIME_CHANGES_LIST = Summary(
+    'changes_service_list_request_processing_seconds',
+    'Time spent processing changes service list ')
+REQUEST_TIME_DOC_UPD = Summary(
+    'db_service_doc_upd_request_processing_seconds',
+    'Time spent processing db_service doc upd')
+REQUEST_TIME_DOC_READ = Summary(
+    'db_service_doc_read_request_processing_seconds',
+    'Time spent processing db_service doc read')
+REQUEST_TIME_DOC_FIND = Summary(
+    'db_service_doc_FIND_request_processing_seconds',
+    'Time spent processing db_service doc find')
+REQUEST_TIME_ATT_READ = Summary(
+    'db_service_att_read_request_processing_seconds',
+    'Time spent processing db_service att read')
+REQUEST_TIME_ATT_UPD = Summary(
+    'db_service_att_upd_request_processing_seconds',
+    'Time spent processing db_service att upd ')
 
 
 class ChangeType(Enum):
@@ -41,7 +56,7 @@ class ChangesService:
         self.changes_db_manager = changes_db_manager
         self.seqnum_generator = seqnum_generator
 
-    @REQUEST_TIME_UPD_CHANGE.time()
+    @REQUEST_TIME_CHANGES_UPD.time()
     def register_change(self,
                         document_record,
                         change_type,
@@ -80,7 +95,7 @@ class DatabaseService:
         self.db_manager = db_manager
         self.changes_service = changes_service
 
-    @REQUEST_TIME_UPD_DOC.time()
+    @REQUEST_TIME_DOC_UPD.time()
     def register(self, document_id, document_record):
         """
         Persiste registro de um documento e a mudança na base de dados.
@@ -96,6 +111,7 @@ class DatabaseService:
         self.changes_service.register_change(
             document_record, ChangeType.CREATE)
 
+    @REQUEST_TIME_DOC_READ.time()
     def read(self, document_id):
         """
         Obtém registro de um documento pelo ID do documento na base de dados.
@@ -125,7 +141,7 @@ class DatabaseService:
                 self.db_manager.list_attachments(document_id)
         return document_record
 
-    @REQUEST_TIME_UPD_DOC.time()
+    @REQUEST_TIME_DOC_UPD.time()
     def update(self, document_id, document_record):
         """
         Atualiza o registro de um documento e a mudança na base de dados.
@@ -160,6 +176,7 @@ class DatabaseService:
         self.changes_service.register_change(
             document_record, ChangeType.DELETE)
 
+    @REQUEST_TIME_DOC_FIND.time()
     def find(self, selector, fields, sort):
         """
         Busca registros de documento por criterios de selecao na base de dados.
@@ -175,7 +192,7 @@ class DatabaseService:
         """
         return self.db_manager.find(selector, fields, sort)
 
-    @REQUEST_TIME_UPD_ATT.time()
+    @REQUEST_TIME_ATT_UPD.time()
     def put_attachment(self, document_id, file_id, content, file_properties):
         """
         Anexa arquivo no registro de um documento pelo ID do documento e
@@ -203,6 +220,7 @@ class DatabaseService:
             )
         self.update(document_id, document_record)
 
+    @REQUEST_TIME_ATT_READ.time()
     def get_attachment(self, document_id, file_id):
         """
         Recupera arquivo anexos ao registro de um documento pelo ID do
@@ -235,6 +253,7 @@ class DatabaseService:
         """
         return self.db_manager.get_attachment_properties(document_id, file_id)
 
+    @REQUEST_TIME_CHANGES_LIST.time()
     def list_changes(self, last_sequence, limit):
         """
         Busca registros de mudança a partir do sequencial informado e retorna

--- a/persistence/services.py
+++ b/persistence/services.py
@@ -1,8 +1,17 @@
 from datetime import datetime
 from enum import Enum
-from uuid import uuid4
+
+from prometheus_client import Summary
 
 from .databases import QueryOperator
+
+
+REQUEST_TIME_UPD_CHANGE = Summary(
+    'request_processing_upd_chg_seconds', 'Time spent processing upd change')
+REQUEST_TIME_UPD_DOC = Summary(
+    'request_processing_upd_doc_seconds', 'Time spent processing upd doc')
+REQUEST_TIME_UPD_ATT = Summary(
+    'request_processing_upd_att_seconds', 'Time spent processing upd att')
 
 
 class ChangeType(Enum):
@@ -32,6 +41,7 @@ class ChangesService:
         self.changes_db_manager = changes_db_manager
         self.seqnum_generator = seqnum_generator
 
+    @REQUEST_TIME_UPD_CHANGE.time()
     def register_change(self,
                         document_record,
                         change_type,
@@ -70,6 +80,7 @@ class DatabaseService:
         self.db_manager = db_manager
         self.changes_service = changes_service
 
+    @REQUEST_TIME_UPD_DOC.time()
     def register(self, document_id, document_record):
         """
         Persiste registro de um documento e a mudança na base de dados.
@@ -114,6 +125,7 @@ class DatabaseService:
                 self.db_manager.list_attachments(document_id)
         return document_record
 
+    @REQUEST_TIME_UPD_DOC.time()
     def update(self, document_id, document_record):
         """
         Atualiza o registro de um documento e a mudança na base de dados.
@@ -163,6 +175,7 @@ class DatabaseService:
         """
         return self.db_manager.find(selector, fields, sort)
 
+    @REQUEST_TIME_UPD_ATT.time()
     def put_attachment(self, document_id, file_id, content, file_properties):
         """
         Anexa arquivo no registro de um documento pelo ID do documento e

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ CouchDB==1.2
 gunicorn==19.7.1
 lxml==4.2.1
 Mako==1.0.7
+prometheus_client==0.2.0
 Pygments==2.2.0
 pyramid==1.9.1
 pyramid-mako==1.0.2


### PR DESCRIPTION

A resolução deste issue envolveu as seguinte atividades:

 - Instalação de Prometheus (localhost) a partir de:
   - https://github.com/prometheus/prometheus/releases/tag/v2.2.1
 - Ajuste de prometheus.yml, acrescentando
   ```  - job_name:       'catalogmanager'

    # Override the global default and scrape targets from this job every 5 seconds.
    scrape_interval: 5s

    static_configs:
      - targets: ['0.0.0.0:6543', '0.0.0.0:8000']
        labels:
          group: 'group1'
    ```
   Em targets ficam os sites para serem monitorados.

 - Execução de prometheus usando o comando:
   ```
   ./prometheus --config.file=prometheus.yml
   ```
 - Instalação da biblioteca prometheus_client==0.2.0
 - Inclusão de prometheus_client==0.2.0 no requirements.txt
 - Inclusão de instruções de prometheus_client nos seguintes pontos:
   - API
   - DatabaseService
   - ChangesService
 - Criação da view: /metrics
