### PR TITLE
[MVP1][tk101] Serviço POST da API de Artigo

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -64,14 +64,20 @@ def main(global_config, **settings):
     config.add_route('home', '/')
 
     def couchdb_settings(request):
-        ini_settings = get_appsettings(global_config['__file__'])
+        ini_config = request.registry.settings
         return {
             'database_uri': '{}:{}'.format(
-                ini_settings['catalogmanager.db.host'],
-                ini_settings['catalogmanager.db.port']
+                ini_config.get('catalogmanager.db.host', ''),
+                ini_config.get('catalogmanager.db.port', '')
             ),
-            'database_username': ini_settings['catalogmanager.db.username'],
-            'database_password': ini_settings['catalogmanager.db.password']
+            'database_username': ini_config.get(
+                'catalogmanager.db.username',
+                ''
+            ),
+            'database_password': ini_config.get(
+                'catalogmanager.db.password',
+                ''
+            )
         }
 
     config.add_request_method(couchdb_settings, 'db_settings', reify=True)

--- a/api/tests/test_article.py
+++ b/api/tests/test_article.py
@@ -1,10 +1,13 @@
-from collections import OrderedDict
 from io import BytesIO
 from unittest.mock import patch
 
-import webtest
+import pytest
 from lxml import etree
+from pyramid.httpexceptions import HTTPInternalServerError, HTTPNotFound
+from webob.multidict import MultiDict
+
 import managers
+from api.views.article import ArticleAPI, ArticleXML, ArticleAsset
 
 
 def _get_file_property(filename, content, size):
@@ -15,39 +18,31 @@ def _get_file_property(filename, content, size):
     }
 
 
-def test_http_get_home(testapp):
-    result = testapp.get('/', status=200)
-    assert result.status == '200 OK'
-    assert result.body == b''
+class MockCGIFieldStorage(object):
+
+    def __init__(self, name, file):
+        self.filename = name
+        self.file = file
 
 
 @patch.object(managers, 'get_article_data')
-def test_http_get_article_calls_get_article_data(mocked_get_article_data,
-                                                 db_settings,
-                                                 testapp):
-    article_id = 'ID123456'
-    mocked_get_article_data.return_value = {"test": "123"}
-    testapp.get('/articles/{}'.format(article_id))
-    mocked_get_article_data.assert_called_once_with(
-        article_id=article_id,
-        **db_settings
-    )
-
-
-@patch.object(managers, 'get_article_data')
-def test_http_get_article_not_found(mocked_get_article_data, testapp):
+def test_http_get_article_not_found(mocked_get_article_data, dummy_request):
     article_id = 'ID123456'
     error_msg = 'Article {} not found'.format(article_id)
     mocked_get_article_data.side_effect = \
         managers.article_manager.ArticleManagerException(
             message=error_msg
         )
-    result = testapp.get('/articles/{}'.format(article_id), expect_errors=True)
-    assert result.status == '404 Not Found'
+    dummy_request.matchdict = {'id': article_id}
+
+    article_api = ArticleAPI(dummy_request)
+    with pytest.raises(HTTPNotFound) as excinfo:
+        article_api.get()
+    assert excinfo.value.message == error_msg
 
 
 @patch.object(managers, 'get_article_data')
-def test_http_get_article_succeeded(mocked_get_article_data, testapp):
+def test_http_get_article_succeeded(mocked_get_article_data, dummy_request):
     article_id = 'ID123456'
     expected = {
         "document_id": article_id,
@@ -58,78 +53,62 @@ def test_http_get_article_succeeded(mocked_get_article_data, testapp):
         },
     }
     mocked_get_article_data.return_value = expected
-    result = testapp.get('/articles/{}'.format(article_id))
-    assert result.status == '200 OK'
-    assert result.json == expected
+    dummy_request.matchdict = {'id': article_id}
+
+    article_api = ArticleAPI(dummy_request)
+    response = article_api.get()
+    assert response.status == '200 OK'
+    assert response.json == expected
 
 
 @patch.object(managers, 'get_article_file')
-def test_http_get_xml_file_calls_get_article_file(mocked_get_article_file,
-                                                  db_settings,
-                                                  testapp,
-                                                  test_article_files):
-    article_id = 'ID123456'
-    with open(test_article_files[0], 'rb') as fb:
-        xml_content = fb.read()
-
-    mocked_get_article_file.return_value = xml_content
-    #XXX penso que não é adequado usar o WebTest para realizar testes desta
-    #natureza -- teste de envio de mensagem do objeto sob teste para uma
-    #das suas dependências. O WebTest tem a finalidade de realizar testes
-    #funcionais em aplicações WSGI.
-    testapp.get('/articles/{}/xml'.format(article_id), expect_errors=True)
-
-    mocked_get_article_file.assert_called_once_with(
-        article_id=article_id,
-        **db_settings
-    )
-
-
-@patch.object(managers, 'get_article_file')
-def test_http_get_xml_file_article_not_found(mocked_get_article_file, testapp):
+def test_http_get_xml_file_article_not_found(mocked_get_article_file,
+                                             dummy_request):
     article_id = 'ID123456'
     error_msg = 'Article {} not found'.format(article_id)
     mocked_get_article_file.side_effect = \
         managers.article_manager.ArticleManagerException(
             message=error_msg
         )
-    result = testapp.get('/articles/{}/xml'.format(article_id),
-                         expect_errors=True)
-    assert result.status == '404 Not Found'
+    dummy_request.matchdict = {'id': article_id}
+
+    article_xml = ArticleXML(dummy_request)
+    with pytest.raises(HTTPNotFound) as excinfo:
+        article_xml.get()
+    assert excinfo.value.message == error_msg
 
 
 @patch.object(managers, 'get_article_file')
-def test_http_get_xml_file_not_found(mocked_get_article_file, testapp):
+def test_http_get_xml_file_not_found(mocked_get_article_file, dummy_request):
     article_id = 'ID123456'
     error_msg = 'Missing XML file {}'.format(article_id)
     mocked_get_article_file.side_effect = \
         managers.article_manager.ArticleManagerException(
             message=error_msg
         )
-    result = testapp.get('/articles/{}/xml'.format(article_id),
-                         expect_errors=True)
-    assert result.status == '404 Not Found'
+    dummy_request.matchdict = {'id': article_id}
+
+    article_xml = ArticleXML(dummy_request)
+    with pytest.raises(HTTPNotFound) as excinfo:
+        article_xml.get()
+    assert excinfo.value.message == error_msg
 
 
 @patch.object(managers, 'get_article_file')
 @patch.object(managers, 'get_article_data')
 def test_http_get_xml_file_calls_get_article_data(mocked_get_article_data,
                                                   mocked_get_article_file,
-                                                  db_settings,
-                                                  testapp,
-                                                  test_article_files):
+                                                  dummy_request,
+                                                  test_xml_file):
     article_id = 'ID123456'
-    with open(test_article_files[0], 'rb') as fb:
-        xml_content = fb.read()
-    #XXX penso que não é adequado usar o WebTest para realizar testes desta
-    #natureza -- teste de envio de mensagem do objeto sob teste para uma
-    #das suas dependências. O WebTest tem a finalidade de realizar testes
-    #funcionais em aplicações WSGI.
-    mocked_get_article_file.return_value = xml_content
-    testapp.get('/articles/{}/xml'.format(article_id))
+    mocked_get_article_file.return_value = test_xml_file.encode('utf-8')
+    dummy_request.matchdict = {'id': article_id}
+
+    article_xml = ArticleXML(dummy_request)
+    article_xml.get()
     mocked_get_article_data.assert_called_once_with(
         article_id=article_id,
-        **db_settings
+        **dummy_request.db_settings
     )
 
 
@@ -140,8 +119,9 @@ def test_http_get_xml_file_calls_set_assets_public_url_if_there_is_assets(
     mocked_set_assets_public_url,
     mocked_get_article_data,
     mocked_get_article_file,
-    testapp,
-    test_article_files
+    dummy_request,
+    test_article_files,
+    test_xml_file
 ):
     article_id = 'ID123456'
     assets = [
@@ -156,18 +136,14 @@ def test_http_get_xml_file_calls_set_assets_public_url_if_there_is_assets(
             'assets': assets
         },
     }
-    with open(test_article_files[0], 'rb') as fb:
-        xml_content = fb.read()
-    #XXX penso que não é adequado usar o WebTest para realizar testes desta
-    #natureza -- teste de envio de mensagem do objeto sob teste para uma
-    #das suas dependências. O WebTest tem a finalidade de realizar testes
-    #funcionais em aplicações WSGI.
-    mocked_get_article_file.return_value = xml_content
-    mocked_set_assets_public_url.return_value = xml_content
-    testapp.get('/articles/{}/xml'.format(article_id))
+    mocked_get_article_file.return_value = test_xml_file.encode('utf-8')
+    mocked_set_assets_public_url.return_value = b'Test123'
+    dummy_request.matchdict = {'id': article_id}
+    article_xml = ArticleXML(dummy_request)
+    article_xml.get()
     mocked_set_assets_public_url.assert_called_once_with(
         article_id=article_id,
-        xml_content=xml_content,
+        xml_content=test_xml_file.encode('utf-8'),
         assets_filenames=assets,
         public_url='/articles/{}/assets/{}'
     )
@@ -180,8 +156,9 @@ def test_http_get_xml_file_doesnt_calls_set_assets_public_url_if_no_assets(
     mocked_set_assets_public_url,
     mocked_get_article_data,
     mocked_get_article_file,
-    testapp,
-    test_article_files
+    dummy_request,
+    test_article_files,
+    test_xml_file
 ):
     article_id = 'ID123456'
     mocked_get_article_data.return_value = {
@@ -191,15 +168,18 @@ def test_http_get_xml_file_doesnt_calls_set_assets_public_url_if_no_assets(
             'xml': "test.xml",
         },
     }
-    #XXX nenhuma interação está sendo testada efetivamente aqui.
-    assert not mocked_set_assets_public_url.called
+    mocked_get_article_file.return_value = test_xml_file.encode('utf-8')
+    dummy_request.matchdict = {'id': article_id}
+    article_xml = ArticleXML(dummy_request)
+    article_xml.get()
+    mocked_set_assets_public_url.assert_not_called()
 
 
 @patch.object(managers, 'get_article_file')
 @patch.object(managers, 'get_article_data')
 def test_http_get_xml_file_succeeded(mocked_get_article_data,
                                      mocked_get_article_file,
-                                     testapp,
+                                     dummy_request,
                                      test_article_files,
                                      test_xml_file):
     #XXX este é um típico teste funcional e deveria ser implementado usando
@@ -223,12 +203,14 @@ def test_http_get_xml_file_succeeded(mocked_get_article_data,
         },
     }
     mocked_get_article_file.return_value = test_xml_file.encode('utf-8')
+    dummy_request.matchdict = {'id': article_id}
 
-    result = testapp.get('/articles/{}/xml'.format(article_id))
-    assert result.status == '200 OK'
-    assert result.content_type == 'application/xml'
-    assert result.body is not None
-    xml_tree = etree.parse(BytesIO(result.body))
+    article_xml = ArticleXML(dummy_request)
+    response = article_xml.get()
+    assert response.status == '200 OK'
+    assert response.content_type == 'application/xml'
+    assert response.body is not None
+    xml_tree = etree.parse(BytesIO(response.body))
     xpath = '{http://www.w3.org/1999/xlink}href'
     xml_nodes = [
         node.get(xpath)
@@ -238,108 +220,53 @@ def test_http_get_xml_file_succeeded(mocked_get_article_data,
         assert expected_href in xml_nodes
 
 
-@patch.object(managers, 'create_file')
-@patch.object(managers, 'put_article')
-def test_http_article_calls_create_file(mocked_put_article,
-                                        mocked_create_file,
-                                        db_settings,
-                                        testapp,
-                                        test_xml_file):
-    #XXX este teste não faz sentido.
-    article_id = 'ID-post-article-123'
-    params = OrderedDict([
-        ('article_id', article_id),
-        ("xml_file",
-         webtest.forms.Upload("test_xml_file.xml",
-                              test_xml_file.encode('utf-8')))
-    ])
-    testapp.put('/articles/{}'.format(article_id),
-                params=params,
-                content_type='multipart/form-data')
-    mocked_create_file.assert_called_once_with(
-        filename="test_xml_file.xml",
-        content=test_xml_file.encode('utf-8')
-    )
-
-
-@patch.object(managers, 'create_file')
-@patch.object(managers, 'put_article')
-def test_http_article_calls_put_article(mocked_put_article,
-                                        mocked_create_file,
-                                        db_settings,
-                                        testapp,
-                                        test_xml_file):
-    #XXX este teste não faz sentido.
-    test_file = _get_file_property("test_xml_file.xml",
-                                   test_xml_file.encode('utf-8'),
-                                   len(test_xml_file))
-    mocked_create_file.return_value = test_file
-    article_id = 'ID-post-article-123'
-    params = OrderedDict([
-        ('article_id', article_id),
-        ("xml_file",
-         webtest.forms.Upload("test_xml_file.xml",
-                              test_xml_file.encode('utf-8')))
-    ])
-    testapp.put('/articles/{}'.format(article_id),
-                params=params,
-                content_type='multipart/form-data')
-    mocked_put_article.assert_called_once_with(
-        article_id=article_id,
-        xml_file=test_file,
-        assets_files=[],
-        **db_settings
-    )
-
-
 @patch.object(managers, 'put_article')
 def test_http_article_calls_put_article_service_error(mocked_put_article,
-                                                      testapp,
+                                                      dummy_request,
                                                       test_xml_file):
-    article_id = 'ID-post-article-123'
+    xml_file = MockCGIFieldStorage("test_xml_file.xml",
+                                   BytesIO(test_xml_file.encode('utf-8')))
+    error_msg = 'Missing XML file {}'.format("test_xml_file")
     mocked_put_article.side_effect = \
         managers.article_manager.ArticleManagerException(
-            message='Missing XML file {}'.format(article_id)
+            message=error_msg
         )
-    params = OrderedDict([
-        ('article_id', article_id),
-        ("xml_file",
-         webtest.forms.Upload("test_xml_file.xml",
-                              test_xml_file.encode('utf-8')))
-    ])
-    result = testapp.put('/articles/{}'.format(article_id),
-                         params=params,
-                         content_type='multipart/form-data',
-                         expect_errors=True)
-    assert result.status == '500 Internal Server Error'
+    dummy_request.POST = MultiDict(
+        [('id', xml_file.filename), ('xml_file', xml_file)]
+    )
+
+    article_api = ArticleAPI(dummy_request)
+    with pytest.raises(HTTPInternalServerError) as excinfo:
+        article_api.put()
+    assert excinfo.value.message == error_msg
 
 
-def test_http_article_put_article_succeeded(testapp,
+@patch.object(managers, 'put_article')
+def test_http_article_put_article_succeeded(mocked_put_article,
+                                            dummy_request,
                                             test_xml_file):
-    article_id = 'ID-put-article-123456'
-    params = OrderedDict([
-        ('article_id', article_id),
-        ("xml_file",
-         webtest.forms.Upload("test_xml_file.xml",
-                              test_xml_file.encode('utf-8')))
-    ])
-    result = testapp.put('/articles/{}'.format(article_id),
-                         params=params,
-                         content_type='multipart/form-data')
-    assert result.status == '201 Created'
+    xml_file = MockCGIFieldStorage("test_xml_file.xml",
+                                   BytesIO(test_xml_file.encode('utf-8')))
+    dummy_request.POST = MultiDict(
+        [('id', xml_file.filename), ('xml_file', xml_file)]
+    )
+
+    article_api = ArticleAPI(dummy_request)
+    response = article_api.put()
+    assert response.status_code == 200
+    assert response.json is not None
+    assert response.json.get('url').endswith(xml_file.filename)
 
 
-@patch.object(managers, 'create_file')
 @patch.object(managers, 'put_article')
 def test_http_article_put_article_with_assets(mocked_put_article,
-                                              mocked_create_file,
-                                              db_settings,
-                                              testapp,
+                                              dummy_request,
                                               test_xml_file,
                                               test_article_files):
     #XXX aqui deveria ser um teste funcional simples, sem qualquer dublê de
     #testes (mocks e afins).
-    article_id = 'ID-post-article-123'
+    xml_file = MockCGIFieldStorage("test_xml_file.xml",
+                                   BytesIO(test_xml_file.encode('utf-8')))
     expected_assets_files = []
     assets_field = []
     for article_file in test_article_files[1:]:
@@ -350,52 +277,44 @@ def test_http_article_put_article_with_assets(mocked_put_article,
                                    file_content,
                                    article_file.lstat().st_size),
             )
-        assets_field.append(
-            ('asset_field', article_file.name, file_content)
-        )
-    test_file = _get_file_property("test_xml_file.xml",
-                                   test_xml_file.encode('utf-8'),
-                                   len(test_xml_file))
-    mocked_create_file.side_effect = [test_file] + expected_assets_files
-    params = OrderedDict([
-        ('article_id', article_id),
-        ("xml_file",
-         webtest.forms.Upload("test_xml_file.xml",
-                              test_xml_file.encode('utf-8')))
-    ])
-    result = testapp.put('/articles/{}'.format(article_id),
-                         params=params,
-                         upload_files=assets_field,
-                         content_type='multipart/form-data')
-    assert result.status == '201 Created'
-    mocked_put_article.assert_called_once_with(
-        article_id=article_id,
-        xml_file=test_file,
-        assets_files=expected_assets_files,
-        **db_settings
+            assets_field.append(
+                ('asset_field',
+                 MockCGIFieldStorage(article_file.name, BytesIO(file_content)))
+            )
+    dummy_request.POST = MultiDict(
+        [('id', xml_file.filename), ('xml_file', xml_file)] + assets_field
     )
+
+    article_api = ArticleAPI(dummy_request)
+    response = article_api.put()
+    mocked_put_article.assert_called_once()
+    assert response.status_code == 200
+    assert response.json is not None
+    assert response.json.get('url').endswith(xml_file.filename)
 
 
 @patch.object(managers, 'get_asset_file')
 def test_http_get_asset_file_calls_get_asset_file(mocked_get_asset_file,
-                                                  db_settings,
-                                                  testapp):
-
-    #XXX este teste não faz sentido.
+                                                  dummy_request):
     article_id = 'ID123456'
     asset_id = 'ID123456'
     mocked_get_asset_file.return_value = '', b'123456Test'
-    testapp.get('/articles/{}/assets/{}'.format(article_id, asset_id))
+    dummy_request.matchdict = {
+        'id': article_id,
+        'asset_id': asset_id
+    }
+    article_asset_api = ArticleAsset(dummy_request)
+    response = article_asset_api.get()
     mocked_get_asset_file.assert_called_once_with(
         article_id=article_id,
         asset_id=asset_id,
-        **db_settings
+        **dummy_request.db_settings
     )
+    assert response.status_code == 200
 
 
 @patch.object(managers, 'get_asset_file')
-def test_http_get_asset_file_not_found(mocked_get_asset_file,
-                                       testapp):
+def test_http_get_asset_file_not_found(mocked_get_asset_file, dummy_request):
     article_id = 'ID123456'
     asset_id = 'a.jpg'
     error_msg = 'Asset {} (Article {}) not found'.format(asset_id, article_id)
@@ -403,21 +322,50 @@ def test_http_get_asset_file_not_found(mocked_get_asset_file,
         managers.article_manager.ArticleManagerException(
             message=error_msg
         )
-    result = testapp.get('/articles/{}/assets/{}'.format(article_id, asset_id),
-                         expect_errors=True)
-    assert result.status == '404 Not Found'
+    dummy_request.matchdict = {
+        'id': article_id,
+        'asset_id': asset_id
+    }
+    article_asset_api = ArticleAsset(dummy_request)
+    with pytest.raises(HTTPNotFound) as excinfo:
+        article_asset_api.get()
+    assert excinfo.value.message == error_msg
 
 
 @patch.object(managers, 'get_asset_file')
 def test_http_get_asset_file_succeeded(mocked_get_asset_file,
-                                       testapp,
+                                       dummy_request,
                                        test_xml_file):
     #XXX este teste deveria usar fixture num setup prévio ao invés de patch.
     article_id = 'ID123456'
     asset_id = 'a.jpg'
     expected = 'text/xml', test_xml_file.encode('utf-8')
     mocked_get_asset_file.return_value = expected
-    result = testapp.get('/articles/{}/assets/{}'.format(article_id, asset_id))
-    assert result.status == '200 OK'
-    assert result.body == expected[1]
-    assert result.content_type == expected[0]
+    dummy_request.matchdict = {
+        'id': article_id,
+        'asset_id': asset_id
+    }
+    article_asset_api = ArticleAsset(dummy_request)
+    response = article_asset_api.get()
+    assert response.status == '200 OK'
+    assert response.body == expected[1]
+    assert response.content_type == expected[0]
+
+
+@patch.object(managers, 'post_article')
+def test_post_article_returns_article_version_url(mocked_post_article,
+                                                  dummy_request,
+                                                  test_xml_file):
+    xml_file = MockCGIFieldStorage("test_xml_file.xml",
+                                   BytesIO(test_xml_file.encode('utf-8')))
+    dummy_request.POST = {
+        'article_id': xml_file.filename,
+        'xml_file': xml_file
+    }
+    article_api = ArticleAPI(dummy_request)
+    response = article_api.collection_post()
+
+    mocked_post_article.assert_called_once()
+    assert response.status_code == 201
+    assert response.json is not None
+    assert response.json.get('url').endswith(xml_file.filename)

--- a/api/tests/test_change.py
+++ b/api/tests/test_change.py
@@ -1,33 +1,27 @@
 from unittest.mock import patch
 
-from pyramid import testing
-
 from api.views.change import ChangeAPI
 
 
 @patch('managers.list_changes')
 def test_change_api_collection_post_calls_list_changes(mocked_list_changes,
-                                                       db_settings,
-                                                       testapp):
-    request = testing.DummyRequest()
-    request.GET = {
+                                                       dummy_request):
+    dummy_request.GET = {
         'since': '123456',
         'limit': 100,
     }
-    request.db_settings = db_settings
-    ChangeAPI.collection_get(ChangeAPI(request))
+    ChangeAPI.collection_get(ChangeAPI(dummy_request))
 
     mocked_list_changes.assert_called_once_with(
-        last_sequence=request.GET['since'],
-        limit=request.GET['limit'],
-        **db_settings
+        last_sequence=dummy_request.GET['since'],
+        limit=dummy_request.GET['limit'],
+        **dummy_request.db_settings
     )
 
 
 @patch('managers.list_changes')
 def test_change_api_collection_post_return_changes_list(mocked_list_changes,
-                                                        db_settings,
-                                                        testapp):
+                                                        dummy_request):
     expected = [
         {
             "change_id": "{}".format(id),
@@ -38,12 +32,10 @@ def test_change_api_collection_post_return_changes_list(mocked_list_changes,
         for id in range(123457, 123466)
     ]
     mocked_list_changes.return_value = expected
-    request = testing.DummyRequest()
-    request.GET = {
+    dummy_request.GET = {
         'since': '123456',
         'limit': 100,
     }
-    request.db_settings = db_settings
-    response = ChangeAPI.collection_get(ChangeAPI(request))
+    response = ChangeAPI.collection_get(ChangeAPI(dummy_request))
     assert response.status_code == 200
     assert response.json == expected

--- a/development.ini
+++ b/development.ini
@@ -6,6 +6,8 @@ pyramid.debug_authorization = false
 pyramid.debug_notfound = false
 pyramid.debug_routematch = false
 pyramid.default_locale_name = en
+pyramid.includes =
+    pyramid_debugtoolbar
 
 catalogmanager.db.host = http://0.0.0.0
 catalogmanager.db.port = 5984

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -1,4 +1,5 @@
 from managers.article_manager import ArticleManager
+from managers.exceptions import ManagerFileError
 from managers.models.article_model import ArticleDocument
 from managers.models.file import File
 from persistence.databases import CouchDBManager

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -56,6 +56,13 @@ def create_file(filename, content):
     return File(file_name=filename, content=content)
 
 
+def post_article(xml_file, **db_settings):
+    """"""
+    article_manager = _get_article_manager(**db_settings)
+    article_manager.add_document()
+    return xml_file.get_version()
+
+
 def put_article(article_id, xml_file, assets_files=[], **db_settings):
     """
     Registra Documento de Artigo, com XML e seus ativos digitais e cria

--- a/managers/article_manager.py
+++ b/managers/article_manager.py
@@ -71,6 +71,9 @@ class ArticleManager:
                     file_properties=asset.file.properties()
                 )
 
+    def add_document(self, article_document):
+        pass
+
     def get_article_data(self, article_id):
         try:
             article_record = self.article_db_service.read(article_id)

--- a/managers/exceptions.py
+++ b/managers/exceptions.py
@@ -1,0 +1,7 @@
+# coding=utf-8
+
+
+class ManagerFileError(Exception):
+
+    def __init__(self, message):
+        self.message = message

--- a/managers/models/file.py
+++ b/managers/models/file.py
@@ -1,5 +1,6 @@
 # coding = utf-8
 
+import hashlib
 import mimetypes
 
 
@@ -8,7 +9,7 @@ class File:
     """
     def __init__(self, file_name, content=None, content_type=None):
         self.name = file_name
-        #XXX a inicialização pode ser incompleta caso o usuário não passe 
+        #XXX a inicialização pode ser incompleta caso o usuário não passe
         #o argumento :attr:`.content`.
         self.content = content
         self.size = len(content) if content is not None else None
@@ -24,3 +25,7 @@ class File:
             'content_type': self.content_type,
             'file_name': self.name,
         }
+
+    def get_version(self):
+        checksum = hashlib.sha1(self.content).hexdigest()
+        return '/'.join([checksum[:13], self.name])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ import os
 import couchdb
 import pytest
 import webtest
+from pyramid.paster import get_appsettings
 
 from api import main
 
@@ -30,24 +31,22 @@ def test_package_A(test_fixture_dir):
 
 @pytest.fixture
 def db_settings():
-    return {
-        'db_host': 'http://127.0.0.1',
-        'db_port': '5984',
-        'username': 'admin',
-        'password': 'password'
-    }
+    return get_appsettings('development.ini')
 
 
 @pytest.fixture
 def testapp(request, db_settings):
-    settings = {'__file__': 'development.ini'}
-    test_app = main(settings)
+    test_app = main({}, **db_settings)
 
     def drop_database():
-        db_server = couchdb.Server('{}:{}'.format(db_settings['db_host'],
-                                                  db_settings['db_port']))
-        db_server.resource.credentials = (db_settings['username'],
-                                          db_settings['password'])
+        db_server = couchdb.Server('{}:{}'.format(
+            db_settings['catalogmanager.db.host'],
+            db_settings['catalogmanager.db.port'])
+        )
+        db_server.resource.credentials = (
+            db_settings['catalogmanager.db.username'],
+            db_settings['catalogmanager.db.password']
+        )
         try:
             db_server.delete('changes')
             db_server.delete('changes_seqnum')

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -36,14 +36,14 @@ def test_add_article_register_change(testapp, test_package_A):
             )
             changes_expected['latest'] = latest
     params = OrderedDict([
-        ("article_id", article_id),
+        ("id", article_id),
         ("xml_file", webtest.forms.Upload(xml_file_path))
     ])
     result = testapp.put(url,
                          params=params,
                          upload_files=assets_field,
                          content_type='multipart/form-data')
-    assert result.status_code == 201
+    assert result.status_code == 200
 
     changes_expected['results'].insert(0,
                                        {


### PR DESCRIPTION
Definição de interfaces para o api POST do artigo:

- Alteração dos testes da view de Artigo para usar DummyRequest
- Inclusão de view POST na API de Artigo com retorno fixo fake
- Criação de interface para inclusão de novos artigos em ArticleManager
- Refatoração de testes
- Ajustes no main() da aplicação Pyramid para recuperar as
configurações do ini file

Fixes #101 
Fixes #79 