### PR TITLE
[MVP1][tk116] Alteração do módulo catalogmanager.persistence

### DIFF
--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -4,15 +4,55 @@ from pathlib import Path
 import pytest
 from pyramid import testing
 
+from managers.article_manager import ArticleManager
+from persistence.databases import InMemoryDBManager
+from persistence.services import ChangesService
+from persistence.seqnum_generator import SeqNumGenerator
+
 
 @pytest.fixture
 def dummy_request():
     request = testing.DummyRequest()
     request.db_settings = {
-        'host': 'http://localhost',
-        'port': '12345'
+        'db_host': 'http://localhost',
+        'db_port': '12345'
     }
     return request
+
+
+@pytest.fixture
+def inmemory_article_manager(request):
+    db_host = 'http://inmemory'
+    articles_dbmanager = InMemoryDBManager(database_uri=db_host,
+                                           database_name='articles')
+    files_dbmanager = InMemoryDBManager(database_uri=db_host,
+                                        database_name='files')
+    changes_dbmanager = InMemoryDBManager(database_uri=db_host,
+                                          database_name='changes')
+    changes_seq_dbmanager = InMemoryDBManager(database_uri=db_host,
+                                              database_name='changes_seqnum')
+
+    def fin():
+        try:
+            articles_dbmanager.drop_database()
+            files_dbmanager.drop_database()
+            changes_dbmanager.drop_database()
+            changes_seq_dbmanager.drop_database()
+        except Exception:
+            pass
+
+    request.addfinalizer(fin)
+    return ArticleManager(
+        articles_dbmanager,
+        files_dbmanager,
+        ChangesService(
+            changes_dbmanager,
+            SeqNumGenerator(
+                changes_seq_dbmanager,
+                'CHANGE'
+            )
+        )
+    )
 
 
 @pytest.fixture

--- a/api/tests/test_article.py
+++ b/api/tests/test_article.py
@@ -356,16 +356,14 @@ def test_http_get_asset_file_succeeded(mocked_get_asset_file,
     assert response.content_type == expected[0]
 
 
-@patch.object(managers, 'create_file')
 @patch.object(managers, 'post_article')
 def test_post_article_invalid_xml(mocked_post_article,
-                                  mocked_create_file,
                                   dummy_request,
                                   test_xml_file):
     xml_file = MockCGIFieldStorage("test_xml_file.xml",
                                    BytesIO(test_xml_file.encode('utf-8')))
     error_msg = 'Invalid XML Content'
-    mocked_create_file.side_effect = \
+    mocked_post_article.side_effect = \
         managers.exceptions.ManagerFileError(
             message=error_msg
         )
@@ -402,10 +400,13 @@ def test_post_article_internal_error(mocked_post_article,
     assert excinfo.value.message == error_msg
 
 
-@patch.object(managers, 'post_article')
-def test_post_article_returns_article_version_url(mocked_post_article,
+@patch.object(managers, '_get_article_manager')
+def test_post_article_returns_article_version_url(mocked__get_article_manager,
+                                                  inmemory_article_manager,
                                                   dummy_request,
                                                   test_xml_file):
+    mocked__get_article_manager.return_value = inmemory_article_manager
+    inmemory_db_settings = '/rawfile'
     xml_file = MockCGIFieldStorage("test_xml_file.xml",
                                    BytesIO(test_xml_file.encode('utf-8')))
     dummy_request.POST = {
@@ -415,7 +416,7 @@ def test_post_article_returns_article_version_url(mocked_post_article,
     article_api = ArticleAPI(dummy_request)
     response = article_api.collection_post()
 
-    mocked_post_article.assert_called_once()
     assert response.status_code == 201
     assert response.json is not None
     assert response.json.get('url').endswith(xml_file.filename)
+    assert response.json.get('url').startswith(inmemory_db_settings)

--- a/api/views/article.py
+++ b/api/views/article.py
@@ -45,18 +45,22 @@ class ArticleAPI:
             raise HTTPBadRequest(detail=e.message)
 
     def collection_post(self):
+        """
+        Receive new Article document package which must contain a XML file.
+        """
         try:
             xml_file_field = self.request.POST.get('xml_file')
-            xml_file = self._get_file_property(xml_file_field)
-            managers.post_article(
+            xml_id = Path(xml_file_field.filename).name
+            xml_file = xml_file_field.file.read()
+            article_url = managers.post_article(
                 article_id=self.request.POST['article_id'],
+                xml_id=xml_id,
                 xml_file=xml_file,
                 **self.request.db_settings
             )
-            body = {
-                'url': '/rawfiles/7ca9f9b2687cb/' + xml_file_field.filename
-            }
-            return Response(status_code=201, json=body)
+            return Response(status_code=201, json={'url': article_url})
+        except managers.exceptions.ManagerFileError as e:
+            raise HTTPBadRequest(detail=e.message)
         except managers.article_manager.ArticleManagerException as e:
             raise HTTPInternalServerError(detail=e.message)
 

--- a/managers/__init__.py
+++ b/managers/__init__.py
@@ -32,10 +32,9 @@ def _get_changes_services(db_settings):
 
 
 def _get_article_manager(**db_settings):
-    database_config = db_settings
-    articles_database_config = database_config.copy()
+    articles_database_config = db_settings.copy()
     articles_database_config['database_name'] = "articles"
-    files_database_config = database_config.copy()
+    files_database_config = db_settings.copy()
     files_database_config['database_name'] = "files"
 
     return ArticleManager(
@@ -80,13 +79,14 @@ def post_article(article_id, xml_id, xml_file, **db_settings):
         codificado em XML
     :rtype: str
     """
+    article_document = ArticleDocument(article_id)
+    article_manager = _get_article_manager(**db_settings)
     try:
-        article_document = ArticleDocument(article_id)
-        article_manager = _get_article_manager(**db_settings)
         article_document.add_version(xml_id, xml_file)
-        return article_manager.add_document(article_document)
     except InvalidXMLContent as e:
         raise ManagerFileError(message=e.message)
+    else:
+        return article_manager.add_document(article_document)
 
 
 def put_article(article_id, xml_file, assets_files=[], **db_settings):

--- a/managers/article_manager.py
+++ b/managers/article_manager.py
@@ -27,9 +27,12 @@ class ArticleManagerMissingAssetFileException(Exception):
 
 class ArticleManager:
 
-    def __init__(self, articles_db_manager, changes_services):
+    def __init__(self, articles_db_manager, files_db_manager,
+                 changes_services):
         self.article_db_service = DatabaseService(
             articles_db_manager, changes_services)
+        self.file_db_service = DatabaseService(
+            files_db_manager, changes_services)
 
     def receive_package(self, id, xml_file, files=None):
         article = self.receive_xml_file(id, xml_file)
@@ -37,7 +40,8 @@ class ArticleManager:
         return article.unexpected_files_list, article.missing_files_list
 
     def receive_xml_file(self, id, xml_file):
-        article = ArticleDocument(id, xml_file)
+        article = ArticleDocument(id)
+        article.xml_file = xml_file
 
         article_record = Record(
             document_id=article.id,
@@ -72,7 +76,14 @@ class ArticleManager:
                 )
 
     def add_document(self, article_document):
-        pass
+        added_file_url = self.file_db_service.add_file(
+            file_id=article_document.xml_file_id,
+            content=article_document.xml_tree.content
+        )
+        article_document.update_version(added_file_url)
+        article_record = article_document.get_record()
+        self.article_db_service.register(article_document.id, article_record)
+        return "/rawfile/" + article_document.xml_file_id
 
     def get_article_data(self, article_id):
         try:

--- a/managers/models/article_model.py
+++ b/managers/models/article_model.py
@@ -1,5 +1,4 @@
 # coding=utf-8
-import hashlib
 from enum import Enum
 
 import os
@@ -74,8 +73,7 @@ class ArticleDocument:
         self.xml_tree = ArticleXMLTree(xml_content)
         if self.xml_tree.xml_error:
             raise InvalidXMLContent
-        checksum = hashlib.sha1(xml_content).hexdigest()
-        self.xml_file_id = '/'.join([checksum[:13], file_id])
+        self.xml_file_id = '/'.join([self.xml_tree.checksum[:13], file_id])
         self.versions.append({
             'data': self.xml_file_id,
             'assets': []

--- a/managers/tests/test_article_model.py
+++ b/managers/tests/test_article_model.py
@@ -1,65 +1,65 @@
+import hashlib
+
+import pytest
 
 from managers.models.article_model import (
     ArticleDocument,
+    InvalidXMLContent
 )
-from managers.xml.xml_tree import (
-    XMLTree,
-)
+from managers.xml.article_xml_tree import ArticleXMLTree
 
 
-def test_article(test_package_A, test_packA_filenames):
-    article = ArticleDocument('ID', test_package_A[0])
-    article.update_asset_files(test_package_A[1:])
-    expected = {
-        'assets': [asset for asset in test_packA_filenames[1:]],
-        'xml': test_packA_filenames[0],
+def test_article_document(test_package_A, test_packA_filenames):
+    article_document = ArticleDocument('ID')
+    assert article_document.id == 'ID'
+    assert article_document.versions == []
+    assert article_document.get_record() == {
+        'document_id': 'ID',
+        'document_type': 'ART',
+        'versions': []
     }
-    assert article.xml_file.name == test_packA_filenames[0]
-    assert article.xml_file.content == test_package_A[0].content
-    assert article.xml_tree.xml_error is None
-    assert article.xml_tree.compare(test_package_A[0].content)
-    assert article.get_record_content() == expected
 
 
-def test_missing_files_list(test_package_B):
-    article = ArticleDocument('ID', test_package_B[0])
-    article.update_asset_files(test_package_B[1:])
+def test_article_invalid_xml():
+    article_document = ArticleDocument('ID')
+    with pytest.raises(InvalidXMLContent):
+        article_document.add_version(
+            'file.xml',
+            b'<article id="a1">\n<text>\n</article>'
+        )
 
-    assert len(article.assets) == 3
-    assert sorted(article.assets.keys()) == sorted(
-        [
-            '0034-8910-rsp-S01518-87872016050006741-gf01.jpg',
-            '0034-8910-rsp-S01518-87872016050006741-gf01-pt.jpg',
-            '0034-8910-rsp-S01518-87872016050006741-gf31.jpg',
+
+def test_article_document_add_version(test_package_A, test_packA_filenames):
+    xml_file = test_package_A[0]
+    checksum = hashlib.sha1(xml_file.content).hexdigest()
+    filename = '/'.join([checksum[:13], xml_file.name])
+    expected = {
+        'document_id': 'ID',
+        'document_type': 'ART',
+        'versions': [
+            {
+                'data': filename,
+                'assets': []
+            }
         ]
-    )
-    assert article.unexpected_files_list == []
-    assert article.missing_files_list == [
-        '0034-8910-rsp-S01518-87872016050006741-gf31.jpg',
-    ]
-
-
-def test_unexpected_files_list(test_package_C, test_packC_filenames):
-    article = ArticleDocument('ID', test_package_C[0])
-    article.update_asset_files(test_package_C[1:])
-
-    assert len(article.assets) == 2
-    assert sorted(article.assets.keys()) == sorted(
-        [
-            '0034-8910-rsp-S01518-87872016050006741-gf01-pt.jpg',
-            '0034-8910-rsp-S01518-87872016050006741-gf01.jpg'
-        ]
-    )
-    assert article.unexpected_files_list == [
-       test_packC_filenames[3]
-    ]
-    assert article.missing_files_list == []
+    }
+    article_document = ArticleDocument('ID')
+    article_document.add_version(file_id=xml_file.name,
+                                 xml_content=xml_file.content)
+    assert article_document.xml_file_id == filename
+    assert article_document.xml_tree is not None
+    assert isinstance(article_document.xml_tree, ArticleXMLTree)
+    assert article_document.xml_tree.xml_error is None
+    assert article_document.xml_tree.compare(xml_file.content)
+    assert article_document.get_record() == expected
 
 
 def test_update_href(test_package_A, test_packA_filenames):
     new_href = 'novo href'
     filename = '0034-8910-rsp-S01518-87872016050006741-gf01.jpg'
-    article = ArticleDocument('ID', test_package_A[0])
+    xml_file = test_package_A[0]
+    article = ArticleDocument('ID')
+    article.xml_file = xml_file
     article.update_asset_files(test_package_A[1:])
     content = article.xml_tree.content
     asset = article.assets.get(filename)

--- a/managers/tests/test_article_model.py
+++ b/managers/tests/test_article_model.py
@@ -31,7 +31,8 @@ def test_article_invalid_xml():
 
 def test_article_document_add_version(test_package_A, test_packA_filenames):
     xml_file = test_package_A[0]
-    checksum = hashlib.sha1(xml_file.content).hexdigest()
+    checksum = hashlib.sha1(
+        ArticleXMLTree(xml_file.content).content).hexdigest()
     filename = '/'.join([checksum[:13], xml_file.name])
     expected = {
         'document_id': 'ID',

--- a/managers/tests/test_managers.py
+++ b/managers/tests/test_managers.py
@@ -56,14 +56,14 @@ def test_get_article_manager(database_config):
 
 
 @patch.object(managers, '_get_article_manager')
-@patch.object(managers.models.article_model.ArticleDocument, '__init__')
-def test_post_article_file_error(mocked_article_model,
+@patch.object(managers.models.article_model.ArticleDocument, 'add_version')
+def test_post_article_file_error(mocked_article_add_version,
                                  mocked__get_article_manager,
                                  test_package_A,
                                  set_inmemory_article_manager):
     mocked__get_article_manager.return_value = set_inmemory_article_manager
     error_msg = 'Invalid XML Content'
-    mocked_article_model.side_effect = \
+    mocked_article_add_version.side_effect = \
         managers.models.article_model.InvalidXMLContent()
     with pytest.raises(managers.exceptions.ManagerFileError) as excinfo:
         managers.post_article(

--- a/managers/xml/article_xml_tree.py
+++ b/managers/xml/article_xml_tree.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import hashlib
 
 from .xml_tree import (
     XMLTree,
@@ -49,3 +50,7 @@ class ArticleXMLTree(XMLTree):
         if self.tree is not None:
             return self.tree.findall(
                 './/*[@{http://www.w3.org/1999/xlink}href]')
+
+    @property
+    def checksum(self):
+        return hashlib.sha1(self.content).hexdigest()

--- a/persistence/databases.py
+++ b/persistence/databases.py
@@ -93,6 +93,10 @@ class BaseDBManager(metaclass=abc.ABCMeta):
         doc = self.read(id)
         return doc.get(self._attachments_properties_key, {}).get(file_id)
 
+    @abc.abstractmethod
+    def insert_file(self, file_id, content) -> None:
+        return NotImplemented
+
 
 class InMemoryDBManager(BaseDBManager):
 
@@ -232,6 +236,11 @@ class InMemoryDBManager(BaseDBManager):
     def list_attachments(self, id):
         doc = self.read(id)
         return list(doc.get(self._attachments_key, {}).keys())
+
+    def insert_file(self, file_id, content):
+        file = self.database.get(id)
+        if not file:
+            self.database.update({file_id: content})
 
 
 class CouchDBManager(BaseDBManager):
@@ -386,6 +395,17 @@ class CouchDBManager(BaseDBManager):
     def list_attachments(self, id):
         doc = self.read(id)
         return list(doc.get(self._attachments_key, {}).keys())
+
+    def insert_file(self, file_id, content):
+        file = self.database.get(file_id)
+        if not file:
+            self.create(id=file_id, document={})
+            doc = self.database.get(file_id)
+            self.database.put_attachment(
+                doc=doc,
+                content=content,
+                filename=file_id
+            )
 
 
 def sort_results(results, sort):

--- a/persistence/databases.py
+++ b/persistence/databases.py
@@ -102,6 +102,7 @@ class InMemoryDBManager(BaseDBManager):
 
     def __init__(self, **kwargs):
         self._database_name = kwargs['database_name']
+        self._database_url = kwargs['database_uri']
         self._attachments_key = 'attachments'
         self._attachments_properties_key = 'attachments_properties'
         self._database = {}
@@ -238,19 +239,21 @@ class InMemoryDBManager(BaseDBManager):
         return list(doc.get(self._attachments_key, {}).keys())
 
     def insert_file(self, file_id, content):
+        id = '/'.join([self._database_url, file_id])
         file = self.database.get(id)
         if not file:
-            self.database.update({file_id: content})
+            self.database.update({id: content})
 
 
 class CouchDBManager(BaseDBManager):
 
     def __init__(self, **kwargs):
         self._database_name = kwargs['database_name']
+        self._database_url = kwargs['database_uri']
         self._attachments_key = '_attachments'
         self._attachments_properties_key = 'attachments_properties'
         self._database = None
-        self._db_server = couchdb.Server(kwargs['database_uri'])
+        self._db_server = couchdb.Server(self._database_url)
         self._db_server.resource.credentials = (
             kwargs['database_username'],
             kwargs['database_password']
@@ -397,14 +400,15 @@ class CouchDBManager(BaseDBManager):
         return list(doc.get(self._attachments_key, {}).keys())
 
     def insert_file(self, file_id, content):
-        file = self.database.get(file_id)
+        id = '/'.join([self._database_url, file_id])
+        file = self.database.get(id)
         if not file:
-            self.create(id=file_id, document={})
-            doc = self.database.get(file_id)
+            self.create(id=id, document={})
+            doc = self.database.get(id)
             self.database.put_attachment(
                 doc=doc,
                 content=content,
-                filename=file_id
+                filename=id
             )
 
 

--- a/persistence/services.py
+++ b/persistence/services.py
@@ -267,6 +267,7 @@ class DatabaseService:
         """
         return self.db_manager.get_attachment_properties(document_id, file_id)
 
+    @REQUEST_TIME_ATT_UPD.time()
     def add_file(self, file_id, content):
         """
         Persiste conteúdo de arquivo na base de dados identificado com ID

--- a/persistence/services.py
+++ b/persistence/services.py
@@ -79,7 +79,7 @@ class ChangesService:
         return change_record['record_id']
 
     def register(self, record_id, change_type):
-        sequencial = str(self.seqnum_generator.new())
+        sequencial = self.seqnum_generator.new()
         change_record = {
             'change_id': sequencial,
             'document_id': record_id,
@@ -87,7 +87,7 @@ class ChangesService:
             'created_date': str(datetime.utcnow().timestamp()),
         }
         self.changes_db_manager.create(
-            sequencial,
+            str(sequencial),
             change_record
         )
         return sequencial

--- a/persistence/tests/conftest.py
+++ b/persistence/tests/conftest.py
@@ -1,7 +1,6 @@
 from datetime import datetime
 from random import randint
 
-from pyramid import testing
 import pytest
 
 from persistence.databases import (

--- a/persistence/tests/test_changes.py
+++ b/persistence/tests/test_changes.py
@@ -69,6 +69,7 @@ def test_register_change_must_keep_sequential_order(database_service):
         isinstance(change_list['change_id'], int)
         for change_list in changes_list
     ])
+    # XXX: Usar sorted(list) ao invés de gerar uma lista ordenada
     assert all([
         changes_list[i]['change_id'] < changes_list[i + 1]['change_id']
         for i in range(len(changes_list) - 1)

--- a/persistence/tests/test_changes.py
+++ b/persistence/tests/test_changes.py
@@ -1,7 +1,8 @@
 from datetime import datetime
+from random import randint
 from uuid import uuid4
 
-from persistence.services import ChangeType
+from persistence.services import ChangeType, SortOrder
 from persistence.models import get_record, RecordType
 
 
@@ -30,7 +31,7 @@ def test_register_change_create(database_service):
     assert check_change['created_date'] is not None
 
 
-def test_register_create(database_service):
+def test_register_change(database_service):
     document_id = 'ID-1234'
     change_id = database_service.changes_service.register(
         document_id,
@@ -38,12 +39,40 @@ def test_register_create(database_service):
     )
     assert change_id is not None
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id]
+        database_service.changes_service.changes_db_manager.database[
+            str(change_id)
+        ]
     )
     assert check_change is not None
     assert check_change['document_id'] == document_id
     assert check_change['type'] == ChangeType.CREATE.value
     assert check_change['created_date'] is not None
+
+
+def test_register_change_must_keep_sequential_order(database_service):
+    changes_service = database_service.changes_service
+    change_type_list = list(ChangeType)
+
+    for counter in range(1, 11):
+        changes_service.register(
+            'ID-{}'.format(counter),
+            change_type_list[randint(0, len(change_type_list)-1)]
+        )
+    sort = [{'change_id': SortOrder.ASC.value}]
+    changes_list = changes_service.changes_db_manager.find(fields=[],
+                                                           filter={},
+                                                           sort=sort)
+
+    assert changes_list is not None
+    assert len(changes_list) == 10
+    assert all([
+        isinstance(change_list['change_id'], int)
+        for change_list in changes_list
+    ])
+    assert all([
+        changes_list[i]['change_id'] < changes_list[i + 1]['change_id']
+        for i in range(len(changes_list) - 1)
+    ])
 
 
 def test_register_update_change(database_service):

--- a/persistence/tests/test_changes.py
+++ b/persistence/tests/test_changes.py
@@ -13,7 +13,7 @@ def get_article_record(content={'Test': 'ChangeRecord'}):
                       created_date=datetime.utcnow())
 
 
-def test_register_create_change(database_service):
+def test_register_change_create(database_service):
     article_record = get_article_record()
     change_id = database_service.changes_service.register_change(
         article_record,
@@ -21,10 +21,27 @@ def test_register_create_change(database_service):
     )
 
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id])
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
     assert check_change is not None
     assert check_change['document_id'] == article_record['document_id']
     assert check_change['document_type'] == article_record['document_type']
+    assert check_change['type'] == ChangeType.CREATE.value
+    assert check_change['created_date'] is not None
+
+
+def test_register_create(database_service):
+    document_id = 'ID-1234'
+    change_id = database_service.changes_service.register(
+        document_id,
+        ChangeType.CREATE
+    )
+    assert change_id is not None
+    check_change = dict(
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
+    assert check_change is not None
+    assert check_change['document_id'] == document_id
     assert check_change['type'] == ChangeType.CREATE.value
     assert check_change['created_date'] is not None
 
@@ -37,7 +54,8 @@ def test_register_update_change(database_service):
     )
 
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id])
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
     assert check_change is not None
     assert check_change['document_id'] == article_record['document_id']
     assert check_change['document_type'] == article_record['document_type']
@@ -53,7 +71,8 @@ def test_register_delete_change(database_service):
     )
 
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id])
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
     assert check_change is not None
     assert check_change['document_id'] == article_record['document_id']
     assert check_change['document_type'] == article_record['document_type']
@@ -84,7 +103,8 @@ def test_add_attachment_create_change(database_service, xml_test):
     )
 
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id])
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
     assert check_change is not None
     assert check_change['attachment_id'] == attachment_id
     assert check_change['document_id'] == article_record['document_id']
@@ -116,7 +136,8 @@ def test_update_attachment_create_change(database_service, xml_test):
     )
 
     check_change = dict(
-        database_service.changes_service.changes_db_manager.database[change_id])
+        database_service.changes_service.changes_db_manager.database[change_id]
+    )
     assert check_change is not None
     assert check_change['attachment_id'] == attachment_id
     assert check_change['document_id'] == article_record['document_id']

--- a/persistence/tests/test_databases.py
+++ b/persistence/tests/test_databases.py
@@ -499,7 +499,9 @@ def test_add_file_insert_file_into_database_ok(
         file_id='href_file1',
         content=xml_test.encode('utf-8')
     )
-    file = db_manager_test.database.get('href_file1')
+    file = db_manager_test.database.get(
+        '/'.join([db_manager_test._database_url, 'href_file1'])
+    )
     assert file is not None
 
 
@@ -534,5 +536,7 @@ def test_add_file_dbmanager_insert_into_database(inmemory_db_setup, xml_test):
         file_id='href_file1',
         content=xml_test.encode('utf-8'),
     )
-    file = inmemory_db_setup.db_manager.database.get('href_file1')
+    file = inmemory_db_setup.db_manager.database.get(
+        '/'.join([inmemory_db_setup.db_manager._database_url, 'href_file1'])
+    )
     assert file is not None

--- a/persistence/tests/test_databases.py
+++ b/persistence/tests/test_databases.py
@@ -489,3 +489,50 @@ def compare_documents(document, expected):
             assert document[k] == expected[k]
     else:
         assert document == expected
+
+
+def test_add_file_insert_file_into_database_ok(
+    db_manager_test,
+    xml_test
+):
+    db_manager_test.insert_file(
+        file_id='href_file1',
+        content=xml_test.encode('utf-8')
+    )
+    file = db_manager_test.database.get('href_file1')
+    assert file is not None
+
+
+def test_add_file_call_dbmanager_insert_file(database_service, xml_test):
+    with patch.object(database_service.db_manager, 'insert_file') \
+            as mocked_insert_file:
+        database_service.add_file(
+            file_id='href_file1',
+            content=xml_test.encode('utf-8'),
+        )
+        mocked_insert_file.assert_called_once_with(
+            file_id='href_file1',
+            content=xml_test.encode('utf-8')
+        )
+
+
+def test_add_file_call_changeservice_register(inmemory_db_setup, xml_test):
+    with patch.object(inmemory_db_setup.changes_service, 'register') \
+            as mocked_change_register:
+        file_id = '/rawfile/href_file1'
+        inmemory_db_setup.add_file(
+            file_id=file_id,
+            content=xml_test.encode('utf-8'),
+        )
+        mocked_change_register.assert_called_once_with(
+            file_id, ChangeType.CREATE
+        )
+
+
+def test_add_file_dbmanager_insert_into_database(inmemory_db_setup, xml_test):
+    inmemory_db_setup.add_file(
+        file_id='href_file1',
+        content=xml_test.encode('utf-8'),
+    )
+    file = inmemory_db_setup.db_manager.database.get('href_file1')
+    assert file is not None

--- a/persistence/tests/test_services.py
+++ b/persistence/tests/test_services.py
@@ -1,4 +1,4 @@
-from unittest.mock import Mock
+from unittest.mock import patch
 
 from persistence.databases import QueryOperator
 from persistence.services import ChangeType, SortOrder
@@ -9,31 +9,31 @@ def test_list_changes_calls_db_manager_find(inmemory_db_setup,
                                             xml_test):
 
     _changes_db_manager = inmemory_db_setup.changes_service.changes_db_manager
-    _changes_db_manager.find = Mock()
-    _changes_db_manager.find.return_value = []
-    last_sequence = '123456'
-    limit = 10
-    expected_fields = [
-        'change_id',
-        'document_id',
-        'document_type',
-        'type',
-        'created_date'
-    ]
-    filter = {
-        'change_id': [
-            (QueryOperator.GREATER_THAN, last_sequence)
+    with patch.object(_changes_db_manager, 'find'):
+        _changes_db_manager.find.return_value = []
+        last_sequence = '123456'
+        limit = 10
+        expected_fields = [
+            'change_id',
+            'document_id',
+            'document_type',
+            'type',
+            'created_date'
         ]
-    }
-    sort = [{'change_id': SortOrder.ASC.value}]
-    inmemory_db_setup.list_changes(last_sequence=last_sequence,
-                                   limit=limit)
-    _changes_db_manager.find.assert_called_once_with(
-        fields=expected_fields,
-        limit=limit,
-        filter=filter,
-        sort=sort
-    )
+        filter = {
+            'change_id': [
+                (QueryOperator.GREATER_THAN, last_sequence)
+            ]
+        }
+        sort = [{'change_id': SortOrder.ASC.value}]
+        inmemory_db_setup.list_changes(last_sequence=last_sequence,
+                                       limit=limit)
+        _changes_db_manager.find.assert_called_once_with(
+            fields=expected_fields,
+            limit=limit,
+            filter=filter,
+            sort=sort
+        )
 
 
 def test_list_changes_returns_db_manager_find_all(inmemory_db_setup,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 cornice==3.4.0
 cornice-swagger==0.6.0
 CouchDB==1.2
+freezegun==0.3.10
 gunicorn==19.7.1
 lxml==4.2.1
 Mako==1.0.7

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,13 @@ requires = [
     'cornice>=3.4.0',
 ]
 
-test_requires = ['webtest', 'pytest', 'pytest-cov', 'pytest-lazy-fixture']
+test_requires = [
+    'webtest',
+    'pytest',
+    'pytest-cov',
+    'pytest-lazy-fixture',
+    'freezegun'
+]
 setup_requires = ['pytest-runner']
 
 setup(


### PR DESCRIPTION
Fixes #116.

- Criação de `insert_file` nos DBManagers
- Criação de `ChangesService.register` com o novo conteúdo do registro
de mudança
- Criação de `DatabaseService.add_file` para persistir arquivos usando o
DBManager e registrando a mudança com `ChangesService.register`
- Ajustes nos fixtures para executar os testes sem duplicação
- Testes unitários e de integração do módulo persistence para o novo
registro de artigos